### PR TITLE
Add \t before the query which prints @abs_srcdir@ in ut-W test

### DIFF
--- a/output/ut-W.source
+++ b/output/ut-W.source
@@ -910,6 +910,7 @@ Parallel()
 (21 rows)
 
 -- Hints on unhintable relations are just ignored
+\t
 /*+Parallel(p1 5 hard) Parallel(s1 3 hard) IndexScan(ft1) SeqScan(cte1)
   TidScan(fs1) IndexScan(t) IndexScan(*VALUES*) */
 EXPLAIN (COSTS false) SELECT id FROM p1_c1_c1 as s1 TABLESAMPLE SYSTEM(10)
@@ -934,8 +935,6 @@ Parallel(s1 3 hard)
 duplication hint:
 error hint:
 
-                                          QUERY PLAN                                           
------------------------------------------------------------------------------------------------
  Append
    ->  Result
          ->  Append
@@ -969,8 +968,8 @@ error hint:
    ->  Function Scan on pg_stat_statements
    ->  Subquery Scan on "*SELECT* 5"
          ->  Values Scan on "*VALUES*"
-(33 rows)
 
+\t
 ALTER SYSTEM SET session_preload_libraries TO DEFAULT;
 SELECT pg_reload_conf();
  pg_reload_conf 

--- a/sql/ut-W.sql
+++ b/sql/ut-W.sql
@@ -171,6 +171,7 @@ EXPLAIN (COSTS false) SELECT * FROM p1;
 EXPLAIN (COSTS false) SELECT id FROM p1 UNION ALL SELECT id FROM p2;
 
 -- Hints on unhintable relations are just ignored
+\t
 /*+Parallel(p1 5 hard) Parallel(s1 3 hard) IndexScan(ft1) SeqScan(cte1)
   TidScan(fs1) IndexScan(t) IndexScan(*VALUES*) */
 EXPLAIN (COSTS false) SELECT id FROM p1_c1_c1 as s1 TABLESAMPLE SYSTEM(10)
@@ -184,5 +185,6 @@ SELECT userid FROM pg_stat_statements fs1
 SELECT x FROM (VALUES (1), (2), (3)) t(x);
 
 
+\t
 ALTER SYSTEM SET session_preload_libraries TO DEFAULT;
 SELECT pg_reload_conf();


### PR DESCRIPTION
The line containing @abs_srcdir@ can be longer than the header line and
if it is, the test will fail.