### PR TITLE
Use ParallelHint in ParallelHintCreate()

### DIFF
--- a/pg_hint_plan.c
+++ b/pg_hint_plan.c
@@ -925,7 +925,7 @@ ParallelHintCreate(const char *hint_str, const char *keyword,
 {
 	ParallelHint *hint;
 
-	hint = palloc(sizeof(ScanMethodHint));
+	hint = palloc(sizeof(ParallelHint));
 	hint->base.hint_str = hint_str;
 	hint->base.keyword = keyword;
 	hint->base.hint_keyword = hint_keyword;


### PR DESCRIPTION
Hello,

There is a bug in ParallelHintCreate(). It is used ScanMethodHint structure instead of ParallelHint. It would be good to backpatch to other branches.