### PR TITLE
fix  compiling error on Solaris

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,10 @@ TARSOURCES = Makefile *.c  *.h COPYRIGHT* \
 	doc/* expected/*.out sql/*.sql sql/maskout.sh \
 	data/data.csv input/*.source output/*.source SPECS/*.spec
 
+ifeq ($(shell uname), SunOS)
+else
 LDFLAGS+=-Wl,--build-id
+endif
 
 installcheck: $(REGRESSION_EXPECTED)
 


### PR DESCRIPTION
 The 'LDFLAGS+=-Wl,--build-id' option is for rpm building in Linux like OS.
The SunOS is not native support the option 'LDFLAGS+=-Wl,--build-id' . So, we disable this option in SunOS while compiling.