### PR TITLE
Fix the failed in regression test

### DIFF
--- a/expected/init.out
+++ b/expected/init.out
@@ -164,8 +164,9 @@ SELECT name, setting, category
     OR name = 'client_min_messages'
  ORDER BY category, name;
 SELECT * FROM settings;
-           name            |  setting  |                  category                   
----------------------------+-----------+---------------------------------------------
+           name            |  setting  |                    category                     
+---------------------------+-----------+-------------------------------------------------
+ client_min_messages       | notice    | Client Connection Defaults / Statement Behavior
  geqo                      | on        | Query Tuning / Genetic Query Optimizer
  geqo_effort               | 5         | Query Tuning / Genetic Query Optimizer
  geqo_generations          | 0         | Query Tuning / Genetic Query Optimizer
@@ -195,7 +196,6 @@ SELECT * FROM settings;
  enable_seqscan            | on        | Query Tuning / Planner Method Configuration
  enable_sort               | on        | Query Tuning / Planner Method Configuration
  enable_tidscan            | on        | Query Tuning / Planner Method Configuration
- client_min_messages       | notice    | Reporting and Logging / When to Log
 (30 rows)
 
 ANALYZE;

--- a/expected/pg_hint_plan.out
+++ b/expected/pg_hint_plan.out
@@ -11,12 +11,12 @@ EXPLAIN (COSTS false) SELECT * FROM t1, t2 WHERE t1.id = t2.id;
 
 EXPLAIN (COSTS false) SELECT * FROM t1, t2 WHERE t1.val = t2.val;
                 QUERY PLAN                 
--------------------------------------------
- Merge Join
-   Merge Cond: (t2.val = t1.val)
-   ->  Index Scan using t2_val on t2
-   ->  Materialize
-         ->  Index Scan using t1_val on t1
+--------------------------------
+ Hash Join
+   Hash Cond: (t2.val = t1.val)
+   ->  Seq Scan on t2
+   ->  Hash
+         ->  Seq Scan on t1
 (5 rows)
 
 LOAD 'pg_hint_plan';
@@ -32,12 +32,12 @@ EXPLAIN (COSTS false) SELECT * FROM t1, t2 WHERE t1.id = t2.id;
 
 EXPLAIN (COSTS false) SELECT * FROM t1, t2 WHERE t1.val = t2.val;
                 QUERY PLAN                 
--------------------------------------------
- Merge Join
-   Merge Cond: (t2.val = t1.val)
-   ->  Index Scan using t2_val on t2
-   ->  Materialize
-         ->  Index Scan using t1_val on t1
+--------------------------------
+ Hash Join
+   Hash Cond: (t2.val = t1.val)
+   ->  Seq Scan on t2
+   ->  Hash
+         ->  Seq Scan on t1
 (5 rows)
 
 /*+ Test (t1 t2) */

--- a/expected/ut-A.out
+++ b/expected/ut-A.out
@@ -2099,6 +2099,8 @@ ERROR:  pg_hint_plan: hint syntax error at or near ""
 DETAIL:  Opening parenthesis is necessary.
 SET client_min_messages TO fatal;
 /*+Set*/SELECT 1;
+ERROR:  pg_hint_plan: hint syntax error at or near ""
+DETAIL:  Opening parenthesis is necessary.
 -- No. A-8-4-11
 RESET client_min_messages;
 SET pg_hint_plan.parse_messages TO DEFAULT;


### PR DESCRIPTION
Hello

When I ran regression tests on REL95_1_8,case ut-A failed.
After investigation, I found that in this case,although 
client_min_messages were set to fatal ,But error-level messages are still output.

The reason for this problem is that PostgreSQL 
modifies the valid value of the client_min_messages option.
before PostgreSQL update:
debug 5 ~ debug 1, log, notice, warning, error, fatal, panic
after PostgreSQL update:
debug 5 ~ debug 1, log, notice, warning, error
After modification, even if client_min_messages are set to fatal, PostgreSQL also sets it to error.
So the expected log should also be updated accordingly.