### PR TITLE
Fix an illegal access

### DIFF
--- a/pg_hint_plan.c
+++ b/pg_hint_plan.c
@@ -3019,8 +3019,11 @@ pg_hint_plan_planner(Query *parse, int cursorOptions, ParamListInfo boundParams)
 		MemoryContext oldcontext;
 
 		oldcontext = MemoryContextSwitchTo(TopMemoryContext);
-		current_hint_str =
-			get_hints_from_comment((char *)error_context_stack->arg);
+		 if(error_context_stack != NULL)
+			 current_hint_str =
+			 	get_hints_from_comment((char *)(error_context_stack->arg));
+		else
+			current_hint_str = NULL;
 		MemoryContextSwitchTo(oldcontext);
 	}
 


### PR DESCRIPTION
In the case of nesting of plpgsql functions, if there is an error in the
 inner layer function, the error_context_stack will be set to null. 
Therefore, add a non empty judgment on the error_context_stack
#This commit is to solve issues #42 