### PR TITLE
Fix compiling error on Solaris

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,9 @@ TARSOURCES = Makefile *.c  *.h COPYRIGHT* \
 	doc/* expected/*.out sql/*.sql sql/maskout.sh \
 	data/data.csv input/*.source output/*.source SPECS/*.spec
 
+ifneq ($(shell uname), SunOS)
 LDFLAGS+=-Wl,--build-id
+endif
 
 installcheck: $(REGRESSION_EXPECTED)
 


### PR DESCRIPTION
The 'LDFLAGS+=-Wl,--build-id' option is for rpm building in Linux like
OS.  The SunOS is not native support the option
'LDFLAGS+=-Wl,--build-id' . So, we disable this option in SunOS while
compiling.
commit introduced by 85e97821b11dde0f57f543c0b1f407f871799d9b.
This fix has been absorbed in other branches. Is PG10 missing this fix?