### PR TITLE
Mark the hint table as the configuration table.

### DIFF
--- a/pg_hint_plan--1.3.5.sql
+++ b/pg_hint_plan--1.3.5.sql
@@ -15,5 +15,8 @@ CREATE UNIQUE INDEX hints_norm_and_app ON hint_plan.hints (
 	application_name
 );
 
+SELECT pg_catalog.pg_extension_config_dump('hint_plan.hints','');
+SELECT pg_catalog.pg_extension_config_dump('hint_plan.hints_id_seq','');
+
 GRANT SELECT ON hint_plan.hints TO PUBLIC;
 GRANT USAGE ON SCHEMA hint_plan TO PUBLIC;


### PR DESCRIPTION
The hint table (hint_plan.hints) is not dumped by pg_dump because it is not marked as Extension Configuration Tables.
Is there a reason why not mark it as the configuration table?

The pg_extension_config_dump('hint_plan.hints', '') should be added to extension's script.
This makes it eisier to migrate the database instance that contains the data of hint_plan.hints by using pg_dump/pg_restore.