### PR TITLE
Fix pg_hint_plan.message_level default value in pg_settings.

### DIFF
--- a/pg_hint_plan.c
+++ b/pg_hint_plan.c
@@ -668,7 +668,7 @@ _PG_init(void)
 							 "Message level of debug messages.",
 							 NULL,
 							 &pg_hint_plan_debug_message_level,
-							 LOG,
+							 INFO,
 							 parse_messages_level_options,
 							 PGC_USERSET,
 							 0,


### PR DESCRIPTION
As issues #62 said, 
when I print the default value of pg_hint_plan.message_level, I found it is not same with the value on document.
The value on document is "INFO", but it prints "LOG".

I made a correction. Please review it.

> Execute log:
> postgres=#` load 'pg_hint_plan';
> LOAD
> postgres=# create extension pg_hint_plan;
> CREATE EXTENSION
> postgres=# select name, setting from pg_settings where name = 'pg_hint_plan.message_level';
>             name        | setting
> ----------------------------+---------
>  pg_hint_plan.message_level   | log
> (1 row)
