### PR TITLE
fix: compiling error on BSD style system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,10 +31,6 @@ TARSOURCES = Makefile *.c  *.h COPYRIGHT* \
 	doc/* expected/*.out sql/*.sql sql/maskout.sh \
 	data/data.csv input/*.source output/*.source SPECS/*.spec
 
-ifneq ($(shell uname), SunOS)
-LDFLAGS+=-Wl,--build-id
-endif
-
 installcheck: $(REGRESSION_EXPECTED)
 
 rpms: rpm13

--- a/SPECS/pg_hint_plan13.spec
+++ b/SPECS/pg_hint_plan13.spec
@@ -59,7 +59,7 @@ if [ ! -d %{_rpmdir} ]; then mkdir -p %{_rpmdir}; fi
 ## Set variables for build environment
 %build
 PATH=/usr/pgsql-13/bin:$PATH
-make USE_PGXS=1 %{?_smp_mflags}
+make USE_PGXS=1 LDFLAGS+=-Wl,--build-id %{?_smp_mflags}
 
 ## Set variables for install
 %install


### PR DESCRIPTION
Not only SunOS does not support the 'LDFLAGS+=-Wl,--build-id' option,
all systems with BSD linker did not support this.
It seems not necessary for compilation,
so, we make it pass from spec file instead of defining in the Makefile.