### PR TITLE
fix that hint clause does not work on extended protocol.

### DIFF
--- a/pg_hint_plan.c
+++ b/pg_hint_plan.c
@@ -3197,10 +3197,13 @@ pg_hint_plan_planner(Query *parse, const char *query_string, int cursorOptions, 
 	/*
 	 * current_hint_str is useless after planning of the top-level query.
 	 */
-	if (recurse_level < 1 && current_hint_str)
+	if (recurse_level < 1)
 	{
-		pfree((void *)current_hint_str);
-		current_hint_str = NULL;
+		if (current_hint_str)
+		{
+			pfree((void *)current_hint_str);
+			current_hint_str = NULL;
+		}
 		current_hint_retrieved = false;
 	}
 
@@ -3239,6 +3242,8 @@ standard_planner_proc:
 	/* The upper-level planner still needs the current hint state */
 	if (HintStateStack != NIL)
 		current_hint_state = (HintState *) lfirst(list_head(HintStateStack));
+
+	current_hint_retrieved = false;
 
 	return result;
 }


### PR DESCRIPTION
Hello,

I found a bug that a hint does not work on the extended protocol.
A sample code is attached.

[libpq-test.zip](https://github.com/ossc-db/pg_hint_plan/files/6048389/libpq-test.zip)

If we execute a query that does not contain a hint clause between PQprepare and PQexecPrepared,
the prepared query does not use the hint.

The cause is that a query that does not contain a hint clause set current_hint_retrieved to true.
If we execute a prepared statement after that, this query processing starts from the planner_hook,
so this query will not get a hint.

To fix this issue, we should set current_hint_retrieved to false if current_hint_str is not NULL.
Thoughts?
