### PR TITLE
added '[',']' for cases with arrays in prepared statements

### DIFF
--- a/pg_hint_plan.c
+++ b/pg_hint_plan.c
@@ -1970,7 +1970,8 @@ get_hints_from_comment(const char *p)
 			!isspace(*p) &&
 			*p != '_' &&
 			*p != ',' &&
-			*p != '(' && *p != ')')
+			*p != '(' && *p != ')' &&
+			*p != '[' && *p != ']')
 			return NULL;
 	}
 


### PR DESCRIPTION
We have an issues with prepared statements that use arrays as arguments.  
In this case pg_hint_plan don't pass preceding sql check. 
This fix adds '[', ']' symbols into the white list.

Example:
```
prepare test_query(numeric[]) as /*+ MergeJoin(t1 t2) */ with test as (select 1 as x) select t1.* from test t1, test t2 where t1.x=any($1) and t1.x = t2.x;
explain execute test_query(array[1,2,3]); 
-- MergeJoin hint will be ignore because of numeric[]
deallocate test_query;```

Is it possible to merge it into the PG13 branch?