### PR TITLE
State hint extractor feature

### DIFF
--- a/expected/pg_hint_plan.out
+++ b/expected/pg_hint_plan.out
@@ -9122,3 +9122,69 @@ error hint:
          Index Cond: (id = t1.id)
 (11 rows)
 
+-- Test enable_state_hint_extractor=on
+do
+$$
+begin
+execute $prepare$ prepare test_hint_extractor(numeric[]) as 
+with recursive 
+dual as (select 'x' dummy, E'\'/*+fake*/' dummy2, $test_string$x /*+test/*/*+ '''E'''''''--*/x$test_string$ as dummy3, 5 dummy_num), 
+hier as (
+select * from dual d1 where d1.dummy_num =any($1) 
+union all 
+select /*+NestLoop(d2 d3) /*MergeJoin(d2 d3) this hint is not actual more*/ */ d2.* from dual d2, dual d3 where d2.dummy=d3.dummy
+union all 
+select /*+HashJoin(h2 h3) */ h2.* from hier h2, dual h3 where h3.dummy=h2.dummy and h2.dummy  is null)
+select --+MergeJoin(h4 d5)
+* from hier h4, dual d5 where h4.dummy = d5.dummy 
+$prepare$;
+end;
+$$;
+begin;
+select set_config('pg_hint_plan.enable_state_hint_extractor', 'on', true);
+ set_config 
+------------
+ on
+(1 row)
+
+explain (costs off) execute test_hint_extractor(array[1,2,3]);
+DEBUG:  pg_hint_plan:
+used hint:
+NestLoop(d2 d3)
+MergeJoin(d5 h4)
+HashJoin(h2 h3)
+not used hint:
+duplication hint:
+error hint:
+
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Merge Join
+   Merge Cond: (h4.dummy = d5.dummy)
+   CTE dual
+     ->  Result
+   CTE hier
+     ->  Recursive Union
+           ->  Append
+                 ->  CTE Scan on dual d1
+                       Filter: ((dummy_num)::numeric = ANY ('{1,2,3}'::numeric[]))
+                 ->  Nested Loop
+                       Join Filter: (d2.dummy = d3.dummy)
+                       ->  CTE Scan on dual d2
+                       ->  CTE Scan on dual d3
+           ->  Hash Join
+                 Hash Cond: (h2.dummy = h3.dummy)
+                 ->  WorkTable Scan on hier h2
+                       Filter: (dummy IS NULL)
+                 ->  Hash
+                       ->  CTE Scan on dual h3
+   ->  Sort
+         Sort Key: h4.dummy
+         ->  CTE Scan on hier h4
+   ->  Sort
+         Sort Key: d5.dummy
+         ->  CTE Scan on dual d5
+(25 rows)
+
+commit;
+deallocate test_hint_extractor;


### PR DESCRIPTION
We have several cases where we need hints to be anywhere inside query and at the same time we need analysis to understand that hints are not part of string literals and we need to be able to disable some hints.

We have compound queries composed from small queries with generated aliases that must be validly hinted too. The most convenient thing is to write hints directly in these parts of the queries when moving and merge hints to the top of the result query it is a too complex.

The "hints_anywhere" flag that was introduced in the master branch is not suitable for us because it will disable validations and does not allow parsing all hints in the request.

This feature add GUC pg_hint_plan.enable_state_hint_extractor.

It provides an parsing algorithm that extracts all hints in query (not just the first ones) with the following rules:

- Ignore hints inside text literals (single quotes)
- Ignore hints inside escaped text literals (like E'xxx\'xxx\''). Algorithm only check that last quote wasn't escaped. It is enough for most cases. Complex/deep escapes not analyzing.
- Ignore hints inside dollar-quoted literals. Nested dollar-quotes are not analyzing and ignoring.
- Nested multiline comments are allowed. All hints inside nested comments - ignored.
- Single line comments allowed. Please note that default "psql" settings will remove singleline comments inside direct calls.

The parser does not check the syntax and proceeds with the assumption that current query is valid (In fact requests with invalid syntax do not reach the hint_planner hook). This allows us make only simple checks without deep validation.