### PR TITLE
Backport merge from PG14. Fix for floating segfault issue

### DIFF
--- a/pg_stat_statements.c
+++ b/pg_stat_statements.c
@@ -756,7 +756,7 @@ generate_normalized_query(pgssJumbleState *jstate, const char *query,
 		 * is kept stable.
 		 */
 		/* And insert a '?' in place of the constant token */
-		norm_query[n_quer_loc++] = '?';
+		n_quer_loc += sprintf(norm_query + n_quer_loc, "?");
 
 		quer_loc = off + tok_len;
 		last_off = off;


### PR DESCRIPTION
We have an issues with segfault on pg_hint_plan for PG13.
We don't have stable case to reproduce theses issues (issue is floating) but it is critical for us because database segfault issue occurs at any time. 
The most suspicious are cases with '?' symbols when working with hint tables, invalid access to the deleted current_hint_str and hint delete functions.  
After we applied these fixes (we merge it from the master branch) we don't see these issues anymore.