### PR TITLE
Added ability to ignore unrecognized hints instead of rasing error

### DIFF
--- a/expected/pg_hint_plan.out
+++ b/expected/pg_hint_plan.out
@@ -9122,3 +9122,34 @@ error hint:
          Index Cond: (id = t1.id)
 (11 rows)
 
+-- Test pg_hint_plan.ignore_unrecognized_hints=on
+begin;
+select set_config('pg_hint_plan.ignore_unrecognized_hints', 'on', true);
+ set_config 
+------------
+ on
+(1 row)
+
+explain (costs off)/*+ unknown_hint internal_query_id(123) MemoizeSupportedINPG14(d1) MergeJoin(d1 d2) */ with dual as (select 'x' as dummy) select * from dual d1, dual d2 where d1.dummy = d2.dummy;
+DEBUG:  pg_hint_plan:
+used hint:
+MergeJoin(d1 d2)
+not used hint:
+duplication hint:
+error hint:
+
+             QUERY PLAN              
+-------------------------------------
+ Merge Join
+   Merge Cond: (d1.dummy = d2.dummy)
+   CTE dual
+     ->  Result
+   ->  Sort
+         Sort Key: d1.dummy
+         ->  CTE Scan on dual d1
+   ->  Sort
+         Sort Key: d2.dummy
+         ->  CTE Scan on dual d2
+(10 rows)
+
+commit;

--- a/sql/pg_hint_plan.sql
+++ b/sql/pg_hint_plan.sql
@@ -1148,3 +1148,9 @@ set pg_hint_plan.parse_messages to 'NOTICE';
 -- all hint types together
 /*+ SeqScan(t1) MergeJoin(t1 t2) Leading(t1 t2) Rows(t1 t2 +10) Parallel(t1 8 hard) Set(random_page_cost 2.0)*/
 EXPLAIN (costs off) SELECT * FROM t1 JOIN t2 ON (t1.id = t2.id) JOIN t3 ON (t3.id = t2.id);
+
+-- Test pg_hint_plan.ignore_unrecognized_hints=on
+begin;
+select set_config('pg_hint_plan.ignore_unrecognized_hints', 'on', true);
+explain (costs off)/*+ unknown_hint internal_query_id(123) MemoizeSupportedINPG14(d1) MergeJoin(d1 d2) */ with dual as (select 'x' as dummy) select * from dual d1, dual d2 where d1.dummy = d2.dummy;
+commit;


### PR DESCRIPTION
We have hints that are used by another extension or hints that are used by an external applications(outside of the database layer). We also have cases when some queries using hints from future versions of pg_hint_plan that are not yet supported in the current version. For example we don't have the "memoize" hint in Postgres 13 but some queries already use this hint because that queries was prepared for a future migration to the Postgres 14.

This feature will add the GUC pg_hint_plan.ignore_unrecognized_hints

The property allows to ignore unrecognized keywords without raising error and continue parsing other hints.