### PR TITLE
Fix #105 Consider indexes other than btree in restrict_indexes().

### DIFF
--- a/pg_hint_plan.c
+++ b/pg_hint_plan.c
@@ -3476,7 +3476,9 @@ restrict_indexes(PlannerInfo *root, ScanMethodHint *hint, RelOptInfo *rel,
 											info->indexkeys[i], false);
 
 					/* deny if any of column attributes don't match */
-					if (strcmp(p_attname, c_attname) != 0 ||
+					if (info->amcanorderbyop == true)					
+					{
+						if (strcmp(p_attname, c_attname) != 0 ||
 						p_info->indcollation[i] != info->indexcollations[i] ||
 						p_info->opclass[i] != info->opcintype[i]||
 						((p_info->indoption[i] & INDOPTION_DESC) != 0)
@@ -3484,6 +3486,19 @@ restrict_indexes(PlannerInfo *root, ScanMethodHint *hint, RelOptInfo *rel,
 						((p_info->indoption[i] & INDOPTION_NULLS_FIRST) != 0)
 						!= info->nulls_first[i])
 						break;
+					}
+					else
+					{
+						/*
+						 * When index does not support order by,
+						 * info->reverse[i] and info->nulls_first[i] are null.
+						 */
+						if (strcmp(p_attname, c_attname) != 0 ||
+							p_info->indcollation[i] != info->indexcollations[i] ||
+							p_info->opclass[i] != info->opcintype[i])
+							break;
+
+					}
 				}
 
 				/* deny this if any difference found */


### PR DESCRIPTION
Fix #105 
 Consider indexes other than btree in restrict_indexes.

When SQL was executed with IndexScan hints for non-btree indexes (such as the gin index) agains a partitioned table, PostgreSQL crashed.
This is because indexes other than btree do not support order by operation and variables related to this were NULL.