### PR TITLE
Fix extension scripts to support all possible upgrade paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,11 +7,22 @@
 MODULES = pg_hint_plan
 HINTPLANVER = 1.5
 
-REGRESS = init base_plan pg_hint_plan ut-init ut-A ut-S ut-J ut-L ut-G ut-R ut-fdw ut-W ut-T ut-fini hints_anywhere
+REGRESS = init base_plan pg_hint_plan ut-init ut-A ut-S ut-J ut-L ut-G ut-R \
+	ut-fdw ut-W ut-T ut-fini hints_anywhere oldextversions
 REGRESS_OPTS = --encoding=UTF8
 
 EXTENSION = pg_hint_plan
-DATA = pg_hint_plan--*.sql
+DATA = \
+	pg_hint_plan--1.3.0.sql \
+	pg_hint_plan--1.3.0--1.3.1.sql \
+	pg_hint_plan--1.3.1--1.3.2.sql \
+	pg_hint_plan--1.3.2--1.3.3.sql \
+	pg_hint_plan--1.3.3--1.3.4.sql \
+	pg_hint_plan--1.3.5--1.3.6.sql  \
+	pg_hint_plan--1.3.4--1.3.5.sql \
+	pg_hint_plan--1.3.6--1.3.7.sql  \
+	pg_hint_plan--1.3.7--1.4.sql \
+	pg_hint_plan--1.4--1.5.sql
 
 EXTRA_CLEAN = RPMS
 

--- a/expected/oldextversions.out
+++ b/expected/oldextversions.out
@@ -1,0 +1,94 @@
+--
+-- tests for upgrade paths
+--
+CREATE EXTENSION pg_hint_plan VERSION "1.3.0";
+\dx+ pg_hint_plan
+Objects in extension "pg_hint_plan"
+       Object description        
+---------------------------------
+ sequence hint_plan.hints_id_seq
+ table hint_plan.hints
+(2 rows)
+
+ALTER EXTENSION pg_hint_plan UPDATE TO "1.3.1";
+\dx+ pg_hint_plan
+Objects in extension "pg_hint_plan"
+       Object description        
+---------------------------------
+ sequence hint_plan.hints_id_seq
+ table hint_plan.hints
+(2 rows)
+
+ALTER EXTENSION pg_hint_plan UPDATE TO "1.3.2";
+\dx+ pg_hint_plan
+Objects in extension "pg_hint_plan"
+       Object description        
+---------------------------------
+ sequence hint_plan.hints_id_seq
+ table hint_plan.hints
+(2 rows)
+
+ALTER EXTENSION pg_hint_plan UPDATE TO "1.3.3";
+\dx+ pg_hint_plan
+Objects in extension "pg_hint_plan"
+       Object description        
+---------------------------------
+ sequence hint_plan.hints_id_seq
+ table hint_plan.hints
+(2 rows)
+
+ALTER EXTENSION pg_hint_plan UPDATE TO "1.3.4";
+\dx+ pg_hint_plan
+Objects in extension "pg_hint_plan"
+       Object description        
+---------------------------------
+ sequence hint_plan.hints_id_seq
+ table hint_plan.hints
+(2 rows)
+
+ALTER EXTENSION pg_hint_plan UPDATE TO "1.3.5";
+\dx+ pg_hint_plan
+Objects in extension "pg_hint_plan"
+       Object description        
+---------------------------------
+ sequence hint_plan.hints_id_seq
+ table hint_plan.hints
+(2 rows)
+
+ALTER EXTENSION pg_hint_plan UPDATE TO "1.3.6";
+\dx+ pg_hint_plan
+Objects in extension "pg_hint_plan"
+       Object description        
+---------------------------------
+ sequence hint_plan.hints_id_seq
+ table hint_plan.hints
+(2 rows)
+
+ALTER EXTENSION pg_hint_plan UPDATE TO "1.3.7";
+\dx+ pg_hint_plan
+Objects in extension "pg_hint_plan"
+       Object description        
+---------------------------------
+ sequence hint_plan.hints_id_seq
+ table hint_plan.hints
+(2 rows)
+
+ALTER EXTENSION pg_hint_plan UPDATE TO "1.4";
+\dx+ pg_hint_plan
+Objects in extension "pg_hint_plan"
+       Object description        
+---------------------------------
+ sequence hint_plan.hints_id_seq
+ table hint_plan.hints
+(2 rows)
+
+ALTER EXTENSION pg_hint_plan UPDATE TO "1.5";
+\dx+ pg_hint_plan
+Objects in extension "pg_hint_plan"
+       Object description        
+---------------------------------
+ sequence hint_plan.hints_id_seq
+ table hint_plan.hints
+(2 rows)
+
+DROP EXTENSION pg_hint_plan;

--- a/expected/ut-fini.out
+++ b/expected/ut-fini.out
@@ -1,2 +1,3 @@
 DROP ROLE IF EXISTS regress_super_user;
 DROP ROLE IF EXISTS regress_normal_user;
+DROP EXTENSION pg_hint_plan;

--- a/pg_hint_plan--1.3.0--1.3.1.sql
+++ b/pg_hint_plan--1.3.0--1.3.1.sql
@@ -1,0 +1,22 @@
+/* pg_hint_plan/pg_hint_plan--1.3.0--1.3.1.sql */
+
+-- complain if script is sourced in psql, rather than via ALTER EXTENSION
+\echo Use "ALTER EXTENSION pg_dbms_stats UPDATE TO '1.3.1'" to load this file. \quit
+
+CREATE TABLE IF NOT EXISTS hint_plan.hints (
+	id					serial	NOT NULL,
+	norm_query_string	text	NOT NULL,
+	application_name	text	NOT NULL,
+	hints				text	NOT NULL,
+	PRIMARY KEY (id)
+);
+CREATE UNIQUE INDEX IF NOT EXISTS hints_norm_and_app ON hint_plan.hints (
+	norm_query_string,
+	application_name
+);
+
+SELECT pg_catalog.pg_extension_config_dump('hint_plan.hints','');
+SELECT pg_catalog.pg_extension_config_dump('hint_plan.hints_id_seq','');
+
+GRANT SELECT ON hint_plan.hints TO PUBLIC;
+GRANT USAGE ON SCHEMA hint_plan TO PUBLIC;

--- a/pg_hint_plan--1.3.0.sql
+++ b/pg_hint_plan--1.3.0.sql
@@ -1,0 +1,22 @@
+/* pg_hint_plan/pg_hint_plan--1.3.0.sql */
+
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "CREATE EXTENSION pg_hint_plan" to load this file. \quit
+
+CREATE TABLE hint_plan.hints (
+	id					serial	NOT NULL,
+	norm_query_string	text	NOT NULL,
+	application_name	text	NOT NULL,
+	hints				text	NOT NULL,
+	PRIMARY KEY (id)
+);
+CREATE UNIQUE INDEX hints_norm_and_app ON hint_plan.hints (
+	norm_query_string,
+	application_name
+);
+
+SELECT pg_catalog.pg_extension_config_dump('hint_plan.hints','');
+SELECT pg_catalog.pg_extension_config_dump('hint_plan.hints_id_seq','');
+
+GRANT SELECT ON hint_plan.hints TO PUBLIC;
+GRANT USAGE ON SCHEMA hint_plan TO PUBLIC;

--- a/pg_hint_plan--1.3.1--1.3.2.sql
+++ b/pg_hint_plan--1.3.1--1.3.2.sql
@@ -1,0 +1,22 @@
+/* pg_hint_plan/pg_hint_plan--1.3.1--1.3.2.sql */
+
+-- complain if script is sourced in psql, rather than via ALTER EXTENSION
+\echo Use "ALTER EXTENSION pg_dbms_stats UPDATE TO '1.3.2'" to load this file. \quit
+
+CREATE TABLE IF NOT EXISTS hint_plan.hints (
+	id					serial	NOT NULL,
+	norm_query_string	text	NOT NULL,
+	application_name	text	NOT NULL,
+	hints				text	NOT NULL,
+	PRIMARY KEY (id)
+);
+CREATE UNIQUE INDEX IF NOT EXISTS hints_norm_and_app ON hint_plan.hints (
+	norm_query_string,
+	application_name
+);
+
+SELECT pg_catalog.pg_extension_config_dump('hint_plan.hints','');
+SELECT pg_catalog.pg_extension_config_dump('hint_plan.hints_id_seq','');
+
+GRANT SELECT ON hint_plan.hints TO PUBLIC;
+GRANT USAGE ON SCHEMA hint_plan TO PUBLIC;

--- a/pg_hint_plan--1.3.2--1.3.3.sql
+++ b/pg_hint_plan--1.3.2--1.3.3.sql
@@ -1,0 +1,22 @@
+/* pg_hint_plan/pg_hint_plan--1.3.2--1.3.3.sql */
+
+-- complain if script is sourced in psql, rather than via ALTER EXTENSION
+\echo Use "ALTER EXTENSION pg_dbms_stats UPDATE TO '1.3.3'" to load this file. \quit
+
+CREATE TABLE IF NOT EXISTS hint_plan.hints (
+	id					serial	NOT NULL,
+	norm_query_string	text	NOT NULL,
+	application_name	text	NOT NULL,
+	hints				text	NOT NULL,
+	PRIMARY KEY (id)
+);
+CREATE UNIQUE INDEX IF NOT EXISTS hints_norm_and_app ON hint_plan.hints (
+	norm_query_string,
+	application_name
+);
+
+SELECT pg_catalog.pg_extension_config_dump('hint_plan.hints','');
+SELECT pg_catalog.pg_extension_config_dump('hint_plan.hints_id_seq','');
+
+GRANT SELECT ON hint_plan.hints TO PUBLIC;
+GRANT USAGE ON SCHEMA hint_plan TO PUBLIC;

--- a/pg_hint_plan--1.3.3--1.3.4.sql
+++ b/pg_hint_plan--1.3.3--1.3.4.sql
@@ -1,17 +1,17 @@
-/* pg_hint_plan/pg_hint_plan--1.5.sql */
+/* pg_hint_plan/pg_hint_plan--1.3.3--1.3.4.sql */
 
--- complain if script is sourced in psql, rather than via CREATE EXTENSION
-\echo Use "CREATE EXTENSION pg_hint_plan" to load this file. \quit
+-- complain if script is sourced in psql, rather than via ALTER EXTENSION
+\echo Use "ALTER EXTENSION pg_dbms_stats UPDATE TO '1.3.4'" to load this file. \quit
 
-CREATE TABLE hint_plan.hints (
+CREATE TABLE IF NOT EXISTS hint_plan.hints (
 	id					serial	NOT NULL,
 	norm_query_string	text	NOT NULL,
 	application_name	text	NOT NULL,
 	hints				text	NOT NULL,
 	PRIMARY KEY (id)
 );
-CREATE UNIQUE INDEX hints_norm_and_app ON hint_plan.hints (
- 	norm_query_string,
+CREATE UNIQUE INDEX IF NOT EXISTS hints_norm_and_app ON hint_plan.hints (
+	norm_query_string,
 	application_name
 );
 

--- a/pg_hint_plan--1.3.4--1.3.5.sql
+++ b/pg_hint_plan--1.3.4--1.3.5.sql
@@ -1,0 +1,22 @@
+/* pg_hint_plan/pg_hint_plan--1.3.4--1.3.5.sql */
+
+-- complain if script is sourced in psql, rather than via ALTER EXTENSION
+\echo Use "ALTER EXTENSION pg_dbms_stats UPDATE TO '1.3.5'" to load this file. \quit
+
+CREATE TABLE IF NOT EXISTS hint_plan.hints (
+	id					serial	NOT NULL,
+	norm_query_string	text	NOT NULL,
+	application_name	text	NOT NULL,
+	hints				text	NOT NULL,
+	PRIMARY KEY (id)
+);
+CREATE UNIQUE INDEX IF NOT EXISTS hints_norm_and_app ON hint_plan.hints (
+ 	norm_query_string,
+	application_name
+);
+
+SELECT pg_catalog.pg_extension_config_dump('hint_plan.hints','');
+SELECT pg_catalog.pg_extension_config_dump('hint_plan.hints_id_seq','');
+
+GRANT SELECT ON hint_plan.hints TO PUBLIC;
+GRANT USAGE ON SCHEMA hint_plan TO PUBLIC;

--- a/pg_hint_plan--1.3.5--1.3.6.sql
+++ b/pg_hint_plan--1.3.5--1.3.6.sql
@@ -1,0 +1,22 @@
+/* pg_hint_plan/pg_hint_plan--1.3.5--1.3.6.sql */
+
+-- complain if script is sourced in psql, rather than via ALTER EXTENSION
+\echo Use "ALTER EXTENSION pg_dbms_stats UPDATE TO '1.3.6'" to load this file. \quit
+
+CREATE TABLE IF NOT EXISTS hint_plan.hints (
+	id					serial	NOT NULL,
+	norm_query_string	text	NOT NULL,
+	application_name	text	NOT NULL,
+	hints				text	NOT NULL,
+	PRIMARY KEY (id)
+);
+CREATE UNIQUE INDEX IF NOT EXISTS hints_norm_and_app ON hint_plan.hints (
+ 	norm_query_string,
+	application_name
+);
+
+SELECT pg_catalog.pg_extension_config_dump('hint_plan.hints','');
+SELECT pg_catalog.pg_extension_config_dump('hint_plan.hints_id_seq','');
+
+GRANT SELECT ON hint_plan.hints TO PUBLIC;
+GRANT USAGE ON SCHEMA hint_plan TO PUBLIC;

--- a/pg_hint_plan--1.3.6--1.3.7.sql
+++ b/pg_hint_plan--1.3.6--1.3.7.sql
@@ -1,0 +1,22 @@
+/* pg_hint_plan/pg_hint_plan--1.3.6--1.3.7.sql */
+
+-- complain if script is sourced in psql, rather than via ALTER EXTENSION
+\echo Use "ALTER EXTENSION pg_dbms_stats UPDATE TO '1.3.7'" to load this file. \quit
+
+CREATE TABLE IF NOT EXISTS hint_plan.hints (
+	id					serial	NOT NULL,
+	norm_query_string	text	NOT NULL,
+	application_name	text	NOT NULL,
+	hints				text	NOT NULL,
+	PRIMARY KEY (id)
+);
+CREATE UNIQUE INDEX IF NOT EXISTS hints_norm_and_app ON hint_plan.hints (
+ 	norm_query_string,
+	application_name
+);
+
+SELECT pg_catalog.pg_extension_config_dump('hint_plan.hints','');
+SELECT pg_catalog.pg_extension_config_dump('hint_plan.hints_id_seq','');
+
+GRANT SELECT ON hint_plan.hints TO PUBLIC;
+GRANT USAGE ON SCHEMA hint_plan TO PUBLIC;

--- a/pg_hint_plan--1.3.7--1.4.sql
+++ b/pg_hint_plan--1.3.7--1.4.sql
@@ -1,0 +1,22 @@
+/* pg_hint_plan/pg_hint_plan--1.3.7--1.4.sql */
+
+-- complain if script is sourced in psql, rather than via ALTER EXTENSION
+\echo Use "ALTER EXTENSION pg_dbms_stats UPDATE TO '1.4'" to load this file. \quit
+
+CREATE TABLE IF NOT EXISTS hint_plan.hints (
+	id					serial	NOT NULL,
+	norm_query_string	text	NOT NULL,
+	application_name	text	NOT NULL,
+	hints				text	NOT NULL,
+	PRIMARY KEY (id)
+);
+CREATE UNIQUE INDEX IF NOT EXISTS hints_norm_and_app ON hint_plan.hints (
+	norm_query_string,
+	application_name
+);
+
+SELECT pg_catalog.pg_extension_config_dump('hint_plan.hints','');
+SELECT pg_catalog.pg_extension_config_dump('hint_plan.hints_id_seq','');
+
+GRANT SELECT ON hint_plan.hints TO PUBLIC;
+GRANT USAGE ON SCHEMA hint_plan TO PUBLIC;

--- a/pg_hint_plan--1.4--1.5.sql
+++ b/pg_hint_plan--1.4--1.5.sql
@@ -1,0 +1,22 @@
+/* pg_hint_plan/pg_hint_plan--1.4--1.5.sql */
+
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "ALTER EXTENSION pg_dbms_stats UPDATE TO '1.5'" to load this file. \quit
+
+CREATE TABLE IF NOT EXISTS hint_plan.hints (
+	id					serial	NOT NULL,
+	norm_query_string	text	NOT NULL,
+	application_name	text	NOT NULL,
+	hints				text	NOT NULL,
+	PRIMARY KEY (id)
+);
+CREATE UNIQUE INDEX IF NOT EXISTS hints_norm_and_app ON hint_plan.hints (
+	norm_query_string,
+	application_name
+);
+
+SELECT pg_catalog.pg_extension_config_dump('hint_plan.hints','');
+SELECT pg_catalog.pg_extension_config_dump('hint_plan.hints_id_seq','');
+
+GRANT SELECT ON hint_plan.hints TO PUBLIC;
+GRANT USAGE ON SCHEMA hint_plan TO PUBLIC;

--- a/sql/oldextversions.sql
+++ b/sql/oldextversions.sql
@@ -1,0 +1,25 @@
+--
+-- tests for upgrade paths
+--
+
+CREATE EXTENSION pg_hint_plan VERSION "1.3.0";
+\dx+ pg_hint_plan
+ALTER EXTENSION pg_hint_plan UPDATE TO "1.3.1";
+\dx+ pg_hint_plan
+ALTER EXTENSION pg_hint_plan UPDATE TO "1.3.2";
+\dx+ pg_hint_plan
+ALTER EXTENSION pg_hint_plan UPDATE TO "1.3.3";
+\dx+ pg_hint_plan
+ALTER EXTENSION pg_hint_plan UPDATE TO "1.3.4";
+\dx+ pg_hint_plan
+ALTER EXTENSION pg_hint_plan UPDATE TO "1.3.5";
+\dx+ pg_hint_plan
+ALTER EXTENSION pg_hint_plan UPDATE TO "1.3.6";
+\dx+ pg_hint_plan
+ALTER EXTENSION pg_hint_plan UPDATE TO "1.3.7";
+\dx+ pg_hint_plan
+ALTER EXTENSION pg_hint_plan UPDATE TO "1.4";
+\dx+ pg_hint_plan
+ALTER EXTENSION pg_hint_plan UPDATE TO "1.5";
+\dx+ pg_hint_plan
+DROP EXTENSION pg_hint_plan;

--- a/sql/ut-fini.sql
+++ b/sql/ut-fini.sql
@@ -1,2 +1,3 @@
 DROP ROLE IF EXISTS regress_super_user;
 DROP ROLE IF EXISTS regress_normal_user;
+DROP EXTENSION pg_hint_plan;


### PR DESCRIPTION
This commit fixes and extends the extension SQL scripts in a few ways, to allow upgrades from the possible versions down to PG10

PostgreSQL allows, since v10, the maintenance of an extension using as base script the oldest version supported in combination of incremental scripts, and a whole set of scripts is added here.  As origin versions may have a partial schema created for the hint table with partial definitions, the correct rules are enforced for each version.

Regression tests are added to cover all these upgrade paths.