### PR TITLE
Fix two issues with build of gather paths

### DIFF
--- a/expected/ut-W.out
+++ b/expected/ut-W.out
@@ -10,6 +10,39 @@ EXPLAIN (COSTS false) SELECT * FROM s1.t1;
  Seq Scan on t1
 (1 row)
 
+-- Note that parallel is not enforced on a single relation without
+-- the GUCs related to parallelism reset.
+/*+Parallel(s1.t1 5 hard)*/
+EXPLAIN (COSTS false) SELECT * FROM s1.t1;
+LOG:  pg_hint_plan:
+used hint:
+not used hint:
+Parallel(s1.t1 5 hard)
+duplication hint:
+error hint:
+
+   QUERY PLAN   
+----------------
+ Seq Scan on t1
+(1 row)
+
+/*+Parallel(s1.t1 5 hard)*/
+EXPLAIN (COSTS false) SELECT * FROM s1.t1 as t11, s1.t1 as t12;
+LOG:  pg_hint_plan:
+used hint:
+not used hint:
+Parallel(s1.t1 5 hard)
+duplication hint:
+error hint:
+
+           QUERY PLAN           
+--------------------------------
+ Nested Loop
+   ->  Seq Scan on t1 t11
+   ->  Materialize
+         ->  Seq Scan on t1 t12
+(4 rows)
+
 SET parallel_setup_cost to 0;
 SET parallel_tuple_cost to 0;
 SET min_parallel_table_scan_size to 0;

--- a/pg_hint_plan.c
+++ b/pg_hint_plan.c
@@ -4848,10 +4848,13 @@ pg_hint_plan_set_rel_pathlist(PlannerInfo * root, RelOptInfo *rel,
 					}
 				}
 
-				/* Generate gather paths */
+				/*
+				 * Generate gather paths.  However, if this is an inheritance
+				 * child, skip it.
+				 */
 				if (rel->reloptkind == RELOPT_BASEREL &&
-					bms_membership(root->all_baserels) != BMS_SINGLETON)
-					generate_gather_paths(root, rel, false);
+					!bms_equal(rel->relids, root->all_baserels))
+					generate_useful_gather_paths(root, rel, false);
 			}
 		}
 	}

--- a/sql/ut-W.sql
+++ b/sql/ut-W.sql
@@ -6,6 +6,12 @@ SET client_min_messages TO LOG;
 
 -- Queries on ordinary tables with default setting
 EXPLAIN (COSTS false) SELECT * FROM s1.t1;
+-- Note that parallel is not enforced on a single relation without
+-- the GUCs related to parallelism reset.
+/*+Parallel(s1.t1 5 hard)*/
+EXPLAIN (COSTS false) SELECT * FROM s1.t1;
+/*+Parallel(s1.t1 5 hard)*/
+EXPLAIN (COSTS false) SELECT * FROM s1.t1 as t11, s1.t1 as t12;
 
 SET parallel_setup_cost to 0;
 SET parallel_tuple_cost to 0;


### PR DESCRIPTION
The following is done:
- pg_hint_plan_set_rel_pathlist() enforces an incorrect check for inheritance children, contrary to upstream commit d8e34fa.
- Currently, parallel hints on single relations cannot be enforced properly without the GUCs related to parallelism to be reset first. Perhaps there is not much of a use-case when it comes to that, but let's add some regression tests to check this default behavior.

Per issue #102.