### PR TITLE
Fix issue with ignoring prepared statements that have array parameters (PG14)

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,9 @@ GUC parameters below affect the behavior of `pg_hint_plan`.
 | `pg_hint_plan.enable_hint_table` | True enbles hinting by table. `true` or `false`.                                                                    | `off`     |
 | `pg_hint_plan.parse_messages`    | Specifies the log level of hint parse error. Valid values are `error`, `warning`, `notice`, `info`, `log`, `debug`. | `INFO`    |
 | `pg_hint_plan.debug_print`       | Controls debug print and verbosity. Valid vaiues are `off`, `on`, `detailed` and `verbose`.                         | `off`     |
-| `pg_hint_plan.message_level`     | Specifies message level of debug print. Valid values are `error`, `warning`, `notice`, `info`, `log`, `debug`.      | `INFO`    |
+| `pg_hint_plan.message_level`     | Specifies message level of debug print. Valid values are `error`, `warning`, `notice`, `info`, `log`, `debug`.      | `LOG`    |
+| `pg_hint_plan.hints_anywhere`    | If it is on, pg_hint_plan reads hints ignoring SQL syntax. This allows hints to be placed anywhere in a query but be cautious of false reads. | `off` |
+| `pg_hint_plan.enable_square_brackets` | Extends set of allowed characters before the hint string to include square brackets, which are commonly used for array arguments in PREPARE statements. Note: it is a default behavior in PG15 and this parameter is removed in that version. | `off` |
 
 ## Installation
 

--- a/doc/pg_hint_plan-ja.html
+++ b/doc/pg_hint_plan-ja.html
@@ -370,7 +370,8 @@ EXPLAIN SELECT * FROM a, b WHERE a.val = b.val;
   <td>動作ログメッセージのログレベルを指定します。有効な値は、debug5、debug4、debug3、debug2、debug1、log、info、notice、warning、またはerrorです。</td><td>LOG</td></tr>
 <tr><td>pg_hint_plan.hints_anywhere</td>
   <td>On の場合、pg_hint_planはSQL構文を無視してヒント文字列の読み取りを行います。この設定ではヒントをSQL文のどこにでも記述することができますが、意図しない文字列がヒントととして読み取られる可能性がある点に注意してください。</td><td>off</td></tr>
-
+<tr><td>pg_hint_plan.enable_square_brackets</td>
+  <td>ヒント文字列の前に許可されている文字のセットを拡張して、角かっこを含めます。角かっこは、PREPARE ステートメントの配列引数に一般的に使用されます。注: これは PG15 のデフォルトの動作であり、このパラメーターはそのバージョンでは削除されています。</td><td>off</td></tr>
 </tbody>
 </table>
 <h2 id="install">インストール</h2>

--- a/doc/pg_hint_plan.html
+++ b/doc/pg_hint_plan.html
@@ -242,6 +242,8 @@ postgres-# SELECT * FROM table1 t1 WHERE key = 'value';
   <td>Specifies message level of debug print. Valid values are error, warning, notice, info, log, debug<n>.</td><td>LOG</td></tr>
 <tr><td>pg_hint_plan.hints_anywhere</td>
   <td>If it is on, pg_hint_plan reads hints ignoring SQL syntax.  This allows to hints to be placed anywhere in a query but be cautious of false reads.</td><td>off</td></tr>
+<tr><td>pg_hint_plan.enable_square_brackets</td>
+  <td>Extends set of allowed characters before the hint string to include square brackets, which are commonly used for array arguments in PREPARE statements. Note: it is a default behavior in PG15 and this parameter is removed in that version.</td><td>off</td></tr>
 </tbody>
 </table>
 <h2 id="install">Installation</h2>

--- a/expected/ut-A.out
+++ b/expected/ut-A.out
@@ -4836,3 +4836,52 @@ DEALLOCATE p1;
 DEALLOCATE p2;
 DEALLOCATE p3;
 DROP TABLE s1.tpc;
+--No.14-1-2 PREPARE query with array parameters
+SET pg_hint_plan.enable_square_brackets TO on;
+PREPARE test_query(numeric[]) AS
+  /*+ MergeJoin(t1 t2) */ WITH test AS
+    (SELECT 1 AS x)
+  SELECT t1.* FROM test t1, test t2
+    WHERE t1.x = ANY($1) AND t1.x = t2.x;
+EXPLAIN EXECUTE test_query(array[1,2,3]);
+LOG:  pg_hint_plan:
+used hint:
+MergeJoin(t1 t2)
+not used hint:
+duplication hint:
+error hint:
+
+                            QUERY PLAN                             
+-------------------------------------------------------------------
+ Merge Join  (cost=0.08..0.10 rows=1 width=4)
+   Merge Cond: (t1.x = t2.x)
+   CTE test
+     ->  Result  (cost=0.00..0.01 rows=1 width=4)
+   ->  Sort  (cost=0.04..0.04 rows=1 width=4)
+         Sort Key: t1.x
+         ->  CTE Scan on test t1  (cost=0.00..0.03 rows=1 width=4)
+               Filter: ((x)::numeric = ANY ('{1,2,3}'::numeric[]))
+   ->  Sort  (cost=0.03..0.04 rows=1 width=4)
+         Sort Key: t2.x
+         ->  CTE Scan on test t2  (cost=0.00..0.02 rows=1 width=4)
+(11 rows)
+
+RESET pg_hint_plan.enable_square_brackets;
+--No.14-1-2b PREPARE query with array parameters default behavior
+PREPARE test_query2(numeric[]) AS
+  /*+ MergeJoin(t1 t2) */ WITH test AS
+    (SELECT 1 AS x)
+  SELECT t1.* FROM test t1, test t2
+    WHERE t1.x = ANY($1) AND t1.x = t2.x;
+EXPLAIN EXECUTE test_query2(array[1,2,3]);
+                         QUERY PLAN                          
+-------------------------------------------------------------
+ Nested Loop  (cost=0.01..0.07 rows=1 width=4)
+   Join Filter: (t1.x = t2.x)
+   CTE test
+     ->  Result  (cost=0.00..0.01 rows=1 width=4)
+   ->  CTE Scan on test t1  (cost=0.00..0.03 rows=1 width=4)
+         Filter: ((x)::numeric = ANY ('{1,2,3}'::numeric[]))
+   ->  CTE Scan on test t2  (cost=0.00..0.02 rows=1 width=4)
+(7 rows)
+

--- a/sql/ut-A.sql
+++ b/sql/ut-A.sql
@@ -1255,3 +1255,20 @@ DEALLOCATE p1;
 DEALLOCATE p2;
 DEALLOCATE p3;
 DROP TABLE s1.tpc;
+
+--No.14-1-2 PREPARE query with array parameters
+SET pg_hint_plan.enable_square_brackets TO on;
+PREPARE test_query(numeric[]) AS
+  /*+ MergeJoin(t1 t2) */ WITH test AS
+    (SELECT 1 AS x)
+  SELECT t1.* FROM test t1, test t2
+    WHERE t1.x = ANY($1) AND t1.x = t2.x;
+EXPLAIN EXECUTE test_query(array[1,2,3]);
+RESET pg_hint_plan.enable_square_brackets;
+--No.14-1-2b PREPARE query with array parameters default behavior
+PREPARE test_query2(numeric[]) AS
+  /*+ MergeJoin(t1 t2) */ WITH test AS
+    (SELECT 1 AS x)
+  SELECT t1.* FROM test t1, test t2
+    WHERE t1.x = ANY($1) AND t1.x = t2.x;
+EXPLAIN EXECUTE test_query2(array[1,2,3]);


### PR DESCRIPTION
This is continuation of the PR https://github.com/ossc-db/pg_hint_plan/pull/98 and change 7c03155c825e483d14ad1b2c619b0263339d8f7e.

Current version of the pg_hint_plan (PG15+) was updated in scope of the previous PR to allow square brackets ('[' and ']') located before the hint string. This is required to support hints for PREPARE statements with array type arguments (e.g. 'PREPARE test_query(numeric[]) AS SELECT /*+ ... */ ...).

In scope of the previous PR it was decided that previous behavior was a bug (i.e. it is hard to use PREPARE statement without such fix), but the fix was introduced only in the head branch (i.e. PG15+), as back-porting it to previous versions (PG14 or lower) may change behavior of existing queries. This is a valid consideration.

However, this still leaves older PG versions with the original problem - this is especially troublesome for public cloud environments where it is not always possible to install custom extension builds.

The proposal is to introduce this fix to older versions as well, but control it with a separate option (GUC), so it will be disabled by default. In this case, the existing behavior will not be changed by default, but anyone affected by this issue could solve it by setting this option.

This solution has its own drawbacks - it introduces a GUC variable in the older version (e.g. PG14), which is then removed in the next version (PG15). However, this will only affects users, which are explicitly using this parameter to get the desired behavior on PG14, and it could be just removed as part of the migration to PG15. It also slightly complicates the code and the documentation - however the change itself is fairly small and simple.

This PR implements following change for the PG14 branch:
* Introduces a Boolean property 'pg_hint_plan.enable_square_brackets' (default value - 'off'). If this property is set, then square brackets are skipped while searching for the hint string.
* Includes regression tests for both default PG14 behavior (i.e. with option set in default value) and with enabled option.
* Updates documentation (pg_hint_plan.html, pg_hint_plan_ja.html and README.MD) to describe this property (also fixing adjacent errors in the documentation, like missing GUCs in README.md).

The PR is targeted to PG14, as it's the version we are mostly interested for now (hitting this issue), but it could be aligned to lower versions as well if required (just let me know).