### PR TITLE
Large cleanup of README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,16 +14,15 @@
 
 ## Synopsis
 
-`pg_hint_plan` makes it possible to tweak PostgreSQL execution plans using so-called "hints" in SQL comments, like `/*+ SeqScan(a) */`.
+`pg_hint_plan` makes it possible to influence PostgreSQL execution plans using so-called "hints" in SQL comments, like `/*+ SeqScan(a) */`.
 
-PostgreSQL uses a cost-based optimizer, which utilizes data statistics, not static rules. The planner (optimizer) esitimates costs of each possible execution plans for a SQL statement then the execution plan with the lowest cost finally be executed. The planner does its best to select the best best execution plan, but is not always perfect, since it doesn't count some properties of the data, for example, correlation between columns.
-
+The PostgreSQL optimizer uses a cost-based approach to determine the most efficient execution plan for a SQL statement. It employs data statistics, rather than static rules, to estimate the costs of each potential plan, then chooses the plan with the lowest cost and executes it. Though the optimizer strives to select the optimal plan, it may not always succeed due to the lack of consideration for certain properties, such as column correlation.
 
 ## Description
 
 ### Basic Usage
 
-`pg_hint_plan` reads hinting phrases in a comment of special form given with the target SQL statement. The special form is beginning by the character sequence `"/\*+"` and ends with `"\*/"`. Hint phrases are consists of hint name and following parameters enclosed by parentheses and delimited by spaces. Each hinting phrases can be delimited by new lines for readability.
+`pg_hint_plan` reads hinting phrases in specially formulated comments given within the target SQL statement. The special form begins with the character sequence `"/\*+"` and ends with `"\*/"`. Hint phrases consist of a hint name followed parameters enclosed by parentheses and delimited by spaces. Hinting phrases may be delimited by new lines for readability.
 
 In the example below, hash join is selected as the joning method and scanning `pgbench_accounts` by sequential scan method.
 
@@ -52,13 +51,13 @@ postgres=#
 
 ## The hint table
 
-Hints are described in a comment in a special form in the above section. This is inconvenient in the case where queries cannot be edited. In the case hints can be placed in a special table named `"hint_plan.hints"`. The table consists of the following columns.
+While hints are typically described in specialy formed comments as described in the above section, this may be inconvenient in cases where queries cannot be edited. In these cases, hints can be placed in a special table named `"hint_plan.hints"`. The table consists of the following columns.
 
 |       column        |                                                                                         description                                                                                         |
 |:--------------------|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `id`                | Unique number to identify a row for a hint. This column is filled automatically by sequence.                                                                                                |
 | `norm_query_string` | A pattern matches to the query to be hinted. Constants in the query have to be replace with '?' as in the following example. White space is significant in the pattern.                     |
-| `application_name`  | The value of `application_name` of sessions to apply the hint. The hint in the example below applies to sessions connected from psql. An empty string means sessions of any `application_name`. |
+| `application_name`  | The value of `application_name` of sessions to apply the hint. An empty string means sessions of any `application_name`. |
 | `hints`             | Hint phrase. This must be a series of hints excluding surrounding comment marks.                                                                                                            |
 
 The following example shows how to operate with the hint table.
@@ -79,7 +78,7 @@ The following example shows how to operate with the hint table.
     DELETE 1
     postgres=#
 
-The hint table is owned by the creator user and having the default privileges at the time of creation. during `CREATE EXTENSION`. Table hints are prioritized over comment hits.
+The hint table is owned by and have the default privileges of the creating user at the time of creation during the `CREATE EXTENSION` command. Table hints are prioritized over comment hits.
 
 ### The types of hints
 
@@ -87,25 +86,25 @@ Hinting phrases are classified into six types based on what kind of object and h
 
 #### Hints for scan methods
 
-Scan method hints enforce specific scanning method on the target table. `pg_hint_plan` recognizes the target table by alias names if any. They are `SeqScan`, `IndexScan` and so on in this kind of hint.
+Scan method hints enforce a specific scanning method on the target table. `pg_hint_plan` recognizes the target table by alias names if any. They are `SeqScan`, `IndexScan`, and so on in this kind of hint.
 
-Scan hints are effective on ordinary tables, inheritance tables, UNLOGGED tables, temporary tables and system catalogs. External (foreign) tables, table functions, VALUES clause, CTEs, views and subquiries are not affected.
+Scan hints are effective on ordinary tables, inheritance tables, UNLOGGED tables, temporary tables, and system catalogs. External (foreign) tables, table functions, VALUES clause, CTEs, views, and subqueries are not affected.
 
     postgres=# /*+
     postgres*#     SeqScan(t1)
     postgres*#     IndexScan(t2 t2_pkey)
     postgres*#  */
-    postgres-# SELECT * FROM table1 t1 JOIN table table2 t2 ON (t1.key = t2.key);
+    postgres-# SELECT * FROM table1 t1 JOIN table2 t2 ON (t1.key = t2.key);
 
 #### Hints for join methods
 
 Join method hints enforce the join methods of the joins involving specified tables.
 
-This can affect on joins only on ordinary tables, inheritance tables, UNLOGGED tables, temporary tables, external (foreign) tables, system catalogs, table functions, VALUES command results and CTEs are allowed to be in the parameter list. But joins on views and sub query are not affected.
+Join method hints are only effective on ordinary tables, inheritance tables, UNLOGGED tables, temporary tables, external (foreign) tables, system catalogs, table functions, VALUES command results, and CTEs. Joins on views and subqueries are not affected.
 
 #### Hint for joining order
 
-This hint "Leading" enforces the order of join on two or more tables. There are two ways of enforcing. One is enforcing specific order of joining but not restricting direction at each join level. Another enfoces join direction additionaly. Details are seen in the [hint list](#hints-list) table.
+This hint "Leading" enforces the order of joining on two or more tables. There are two ways of enforcing join order. One is enforcing the specific order of joining, but not restricting the direction at each join level. The other enfoces both join order and join direction. Additional details are available in the [hint list](#hints-list) table.
 
     postgres=# /*+
     postgres*#     NestLoop(t1 t2)
@@ -113,12 +112,12 @@ This hint "Leading" enforces the order of join on two or more tables. There are 
     postgres*#     Leading(t1 t2 t3)
     postgres*#  */
     postgres-# SELECT * FROM table1 t1
-    postgres-#     JOIN table table2 t2 ON (t1.key = t2.key)
-    postgres-#     JOIN table table3 t3 ON (t2.key = t3.key);
+    postgres-#     JOIN table2 t2 ON (t1.key = t2.key)
+    postgres-#     JOIN table3 t3 ON (t2.key = t3.key);
 
 #### Hint for row number correction
 
-This hint "Rows" corrects row number misestimation of joins that comes from restrictions of the planner.
+This hint "Rows" modifies row number estimates for joins that come from the planner.
 
     postgres=# /*+ Rows(a b #10) */ SELECT... ; Sets rows of join result to 10
     postgres=# /*+ Rows(a b +10) */ SELECT... ; Increments row number by 10
@@ -127,7 +126,9 @@ This hint "Rows" corrects row number misestimation of joins that comes from rest
 
 #### Hint for parallel plan
 
-This hint `Parallel` enforces parallel execution configuration on scans. The third parameter specifies the strength of enfocement. `soft` means that `pg_hint_plan` only changes `max_parallel_worker_per_gather` and leave all others to planner. `hard` changes other planner parameters so as to forcibly apply the number. This can affect on ordinary tables, inheritnce parents, unlogged tables and system catalogues. External tables, table functions, values clause, CTEs, views and subqueries are not affected. Internal tables of a view can be specified by its real name/alias as the target object. The following example shows that the query is enforced differently on each table.
+This hint `Parallel` enforces parallel execution configuration on scans. The first and second parameter specifiy the table and number of workers to be used for the paralel scan. The third parameter specifies the strength of enfocement. `soft` means that `pg_hint_plan` only changes `max_parallel_worker_per_gather`, leaving all other parameters to the planner. `hard` changes other planner parameters so as to forcibly apply the number.
+
+Parallel plan hints can affect scans on ordinary tables, inheritence parents, unlogged tables, and system catalogs. External tables, table functions, values clause, CTEs, views, and subqueries are not affected. Note that the internal tables of a view can be specified by its real name/alias as the target object. The following example shows that the query is enforced differently on each table.
 
     postgres=# explain /*+ Parallel(c1 3 hard) Parallel(c2 5 hard) */
            SELECT c2.a FROM c1 JOIN c2 ON (c1.a = c2.a);
@@ -154,7 +155,7 @@ This hint `Parallel` enforces parallel execution configuration on scans. The thi
 
 #### GUC parameters temporarily setting
 
-`Set` hint changes GUC parameters just while planning. GUC parameter shown in [Query Planning](http://www.postgresql.org/docs/current/static/runtime-config-query.html) can have the expected effects on planning unless any other hint conflicts with the planner method configuration parameters. The last one among hints on the same GUC parameter makes effect. [GUC parameters for `pg_hint_plan`](#guc-parameters-for-pg_hint_plan) are also settable by this hint but it won't work as your expectation. See [Restrictions](#restrictions) for details.
+`Set` hints change GUC parameters for a query only at plan time rather than both planning and execution like a typical SET command. GUC parameter shown in [Query Planning](http://www.postgresql.org/docs/current/static/runtime-config-query.html) can have the expected effects on planning unless any other hint conflicts with the planner method configuration parameters. In the case of multiple hints on the same GUC parameter, the last one will take effect. [GUC parameters for `pg_hint_plan`](#guc-parameters-for-pg_hint_plan) are also settable by this hint but will not work as expected. See [Restrictions](#restrictions) for details.
 
     postgres=# /*+ Set(random_page_cost 2.0) */
     postgres-# SELECT * FROM table1 t1 WHERE key = 'value';
@@ -166,17 +167,17 @@ GUC parameters below affect the behavior of `pg_hint_plan`.
 
 |         Parameter name         |                                               Description                                                             | Default   |
 |:-------------------------------|:----------------------------------------------------------------------------------------------------------------------|:----------|
-| `pg_hint_plan.enable_hint`       | True enbles `pg_hint_plan`.                                                                                         | `on`      |
+| `pg_hint_plan.enable_hint`       | True enables `pg_hint_plan`.                                                                                        | `on`      |
 | `pg_hint_plan.enable_hint_table` | True enbles hinting by table. `true` or `false`.                                                                    | `off`     |
 | `pg_hint_plan.parse_messages`    | Specifies the log level of hint parse error. Valid values are `error`, `warning`, `notice`, `info`, `log`, `debug`. | `INFO`    |
-| `pg_hint_plan.debug_print`       | Controls debug print and verbosity. Valid vaiues are `off`, `on`, `detailed` and `verbose`.                         | `off`     |
+| `pg_hint_plan.debug_print`       | Controls debug print and verbosity. Valid vaiues are `off`, `on`, `detailed`, and `verbose`.                        | `off`     |
 | `pg_hint_plan.message_level`     | Specifies message level of debug print. Valid values are `error`, `warning`, `notice`, `info`, `log`, `debug`.      | `INFO`    |
 
 ## Installation
 
 This section describes the installation steps.
 
-### building binary module
+### Building Binary Module
 
 Simply run `make` at the top of the source tree, then `make install` as an appropriate user. The `PATH` environment variable should be set properly for the target PostgreSQL for this process.
 
@@ -188,13 +189,13 @@ Simply run `make` at the top of the source tree, then `make install` as an appro
 
 ### Loading `pg_hint_plan`
 
-Basically `pg_hint_plan` does not require `CREATE EXTENSION`. Simply loading it by `LOAD` command will activate it and of course you can load it globally by setting `shared_preload_libraries` in `postgresql.conf`. Or you might be interested in `ALTER USER SET`/`ALTER DATABASE SET` for automatic loading for specific sessions.
+`pg_hint_plan` does not require `CREATE EXTENSION`. Simply loading it by `LOAD` command will activate it and of course you can load it globally by setting `shared_preload_libraries` in `postgresql.conf`. Or you might be interested in `ALTER USER SET`/`ALTER DATABASE SET` for automatic loading for specific sessions.
 
     postgres=# LOAD 'pg_hint_plan';
     LOAD
     postgres=#
 
-Do `CREATE EXTENSION` and `SET pg_hint_plan.enable_hint_tables TO on` if you are planning to hint tables.
+Use `CREATE EXTENSION` and `SET pg_hint_plan.enable_hint_tables TO on` if you want to make use of hint tables.
 
 ## Unistallation
 
@@ -208,7 +209,7 @@ Do `CREATE EXTENSION` and `SET pg_hint_plan.enable_hint_tables TO on` if you are
 
 #### Syntax and placement
 
-`pg_hint_plan` reads hints from only the first block comment and any characters except alphabets, digits, spaces, underscores, commas and parentheses stops parsing immediately. In the following example `HashJoin(a b)` and `SeqScan(a)` are parsed as hints but `IndexScan(a)` and `MergeJoin(a b)` are not.
+`pg_hint_plan` reads hints from only the first comment block and any character other than alphabets, digits, spaces, underscores, commas, or parentheses, stops parsing immediately. In the following example `HashJoin(a b)` and `SeqScan(a)` are parsed as hints, but `IndexScan(a)` and `MergeJoin(a b)` are not.
 
     postgres=# /*+
     postgres*#    HashJoin(a b)
@@ -236,13 +237,13 @@ Do `CREATE EXTENSION` and `SET pg_hint_plan.enable_hint_tables TO on` if you are
 
 `pg_hint_plan` works for queries in PL/pgSQL scripts with some restrictions.
 
--   Hints affect only on the following kind of queires.
-    -   Queries that returns one row. (`SELECT`, `INSERT`, `UPDATE` and `DELETE`)
-    -   Queries that returns multiple rows. (`RETURN QUERY`)
+-   Hints affect only on the following kind of queries.
+    -   Queries that return one row. (`SELECT`, `INSERT`, `UPDATE` and `DELETE`)
+    -   Queries that return multiple rows. (`RETURN QUERY`)
     -   Dynamic SQL statements. (`EXECUTE`)
     -   Cursor open. (`OPEN`)
     -   Loop over result of a query (`FOR`)
--   A hint comment have to be placed after the first word in a query as the following since preceding comments are not sent as a part of the query.
+-   A hint comment must be placed after the first word in a query, per the following example, as preceding comments are not sent as a part of the query.
 
         postgres=# CREATE FUNCTION hints_func(integer) RETURNS integer AS $$
         postgres$# DECLARE
@@ -259,15 +260,15 @@ Do `CREATE EXTENSION` and `SET pg_hint_plan.enable_hint_tables TO on` if you are
 
 #### Letter case in the object names
 
-Unlike the way PostgreSQL handles object names, `pg_hint_plan` compares bare object names in hints against the database internal object names in case sensitive way. Therefore an object name TBL in a hint matches only "TBL" in database and does not match any unquoted names like TBL, tbl or Tbl.
+Unlike the way PostgreSQL handles object names, `pg_hint_plan` compares bare object names in hints against the database internal object names and are case sensitive. Therefore an object name TBL in a hint matches only "TBL" in database and does not match any unquoted names in a query like TBL, tbl or Tbl.
 
 #### Escaping special chacaters in object names
 
-The objects as the hint parameter should be enclosed by double quotes if they includes parentheses, double quotes and white spaces. The escaping rule is the same as PostgreSQL.
+The objects in a hint parameter should be enclosed by double quotes if they includes parentheses, double quotes, or white spaces. The escaping rule is the same as PostgreSQL.
 
 ### Distinction between multiple occurances of a table
 
-`pg_hint_plan` identifies the target object by using aliases if exists. This behavior is usable to point a specific occurance among multiple occurances of one table.
+`pg_hint_plan` uses alises to identify the target objects, if present. This allows you to specificy a specific occurance of a table among multiple occurances. 
 
     postgres=# /*+ HashJoin(t1 t1) */
     postgres-# EXPLAIN SELECT * FROM s1.t1
@@ -288,7 +289,7 @@ The objects as the hint parameter should be enclosed by double quotes if they in
 
 #### Underlying tables of views or rules
 
-Hints are not applicable on views itself, but they can affect the queries within if the object names match the object names in the expanded query on the view. Assigning aliases to the tables in a view enables them to be manipulated from outside the view.
+Hints are not applicable on views themselves, but they can affect the queries within a view if a hinted object name matches the object name in the expanded query on the view. Assigning aliases to the tables in a view enables them to be manipulated from outside the view.
 
     postgres=# CREATE VIEW v1 AS SELECT * FROM t2;
     postgres=# EXPLAIN /*+ HashJoin(t1 v1) */
@@ -303,15 +304,15 @@ Hints are not applicable on views itself, but they can affect the queries within
 
 #### Inheritance tables
 
-Hints can point only the parent of an inheritance tables and the hint affect all the inheritance. Hints simultaneously point directly to children are not in effect.
+Hints can only target the parent of an inheritance table. The hint affects all children of the inheritance table. Direct hints to children are not effective.
 
 #### Hinting on multistatements
 
-One multistatement can have exactly one hint comment and the hints affects all of the individual statement in the multistatement. Notice that the seemingly multistatement on the interactive interface of psql is internally a sequence of single statements so hints affects only on the statement just following.
+One multistatement can have only one hint block, however the included hints will affect all of the individual statements in the multistatement. Note that within the interactive interface of psql, what may seem as a multistatement is internally a sequence of single statements, so hints affect only the initial following statement.
 
 #### VALUES expressions
 
-`VALUES` expressions in `FROM` clause are named as `*VALUES*` internally so it is hintable if it is the only `VALUES` in a query. Two or more `VALUES` expressions in a query seem distinguishable looking at its explain result. But in reality, it is merely a cosmetic and they are not distinguishable.
+`VALUES` expressions in `FROM` clause are named as `*VALUES*` internally so it is hintable if it is the only `VALUES` in a query. Two or more `VALUES` expressions in a query seem distinguishable looking at its explain result, but in reality it is merely a cosmetic and they are not distinguishable.
 
     postgres=# /*+ MergeJoin(*VALUES*_1 *VALUES*) */
           EXPLAIN SELECT * FROM (VALUES (1, 1), (2, 2)) v (a, b)
@@ -334,7 +335,7 @@ Subqueries in the following context occasionally can be hinted using the name `A
     = ANY (SELECT ... {LIMIT | OFFSET ...} ...)
     = SOME (SELECT ... {LIMIT | OFFSET ...} ...)
 
-For these syntaxes, planner internally assigns the name to the subquery when planning joins on tables including it, so join hints are applicable on such joins using the implicit name as the following.
+For these syntaxes, the planner internally assigns a name to the subquery when planning joins on tables including it, so join hints are applicable on such joins using the implicit name, per the following example.
 
     postgres=# /*+HashJoin(a1 ANY_subquery)*/
     postgres=# EXPLAIN SELECT *
@@ -352,52 +353,52 @@ For these syntaxes, planner internally assigns the name to the subquery when pla
 
 #### Using `IndexOnlyScan` hint
 
-Index scan may unexpectedly performed on another index when the index specifed in IndexOnlyScan hint cannot perform index only scan.
+An unexpected index scan on a different index may be performed when the IndexOnlyScan hint specifies an index that cannot perform an index-only scan.
 
 #### Behavior of `NoIndexScan`
 
-`NoIndexScan` hint involes `NoIndexOnlyScan`.
+The `NoIndexScan` hint will also prevent index-only scans, similar to `NoIndexOnlyScan`.
 
 #### Parallel hint and `UNION`
 
-A `UNION` can run in parallel only when all underlying subqueries are parallel-safe. Conversely enforcing parallel on any of the subqueries let a parallel-executable `UNION` run in parallel. Meanwhile, a parallel hint with zero workers hinhibits a scan from executed in parallel.
+A `UNION` can run in parallel only when all underlying subqueries are parallel-safe. Conversely, enforcing parallel on any of the subqueries lets a parallel-executable `UNION` run in parallel. Note a parallel hint with zero workers prevents a scan from being executed in parallel.
 
 #### Setting `pg_hint_plan` parameters by Set hints
 
-`pg_hint_plan` parameters change the behavior of itself so some parameters doesn't work as expected.
+`pg_hint_plan` parameters can change the behavior of `pg_hint_plan` itself, which may case some parameters to not work as expected.
 
 -   Hints to change `enable_hint`, `enable_hint_tables` are ignored even though they are reported as "used hints" in debug logs.
 -   Setting `debug_print` and `message_level` works from midst of the processing of the target query.
 
 ## Errors
 
-`pg_hint_plan` stops parsing on any error and uses hints already parsed on the most cases. Following are the typical errors.
+`pg_hint_plan` stops parsing on any error but continues using already parsed hints in the most cases. The following are typical errors.
 
 #### Syntax errors
 
-Any syntactical errors or wrong hint names are reported as a syntax error. These errors are reported in the server log with the message level specified by `pg_hint_plan.message_level` if `pg_hint_plan.debug_print` is on and above.
+Any syntactical errors or wrong hint names are reported as a syntax error. These errors are reported in the server log with the message level specified by `pg_hint_plan.message_level` if `pg_hint_plan.debug_print` is on and has already been parsed.
 
 #### Object misspecifications
 
-Object misspecifications result in silent ignorance of the hints. This kind of error is reported as "not used hints" in the server log by the same condition as syntax errors.
+Object misspecifications will result in hints being silently ignored. This kind of error is reported as "not used hints" in the server log under the same conditions as syntax errors.
 
 #### Redundant or conflicting hints
 
-The last hint will be active when redundant hints or hints conflicting with each other. This kind of error is reported as "duplication hints" in the server log by the same condition to syntax errors.
+In cases of redundent hints or multiple hints conflicting with each other, the last hint parsed will be active. This kind of error is reported as "duplication hints" in the server log under the same conditions as syntax errors.
 
 #### Nested comments
 
-Hint comment cannot include another block comment within. If `pg_hint_plan` finds it, differently from other erros, it stops parsing and abandans all hints already parsed. This kind of error is reported in the same manner as other errors.
+Hint comments cannot contain nested comment blocks. If `pg_hint_plan` encounters one, it will stop parsing and, unlike other errors, abandon all previously parsed hint. This kind of error is reported in the same way as other errors.
 
 ## Functional limitations
 
 #### Influences of some of planner GUC parameters
 
-The planner does not try to consider joining order for FROM clause entries more than `from_collapse_limit`. `pg_hint_plan` cannot affect joining order as expected for the case.
+The planner does not try to consider joining order for FROM clause entries more than `from_collapse_limit`. Therefore, `pg_hint_plan` cannot affect join order as expected for those cases.
 
 #### Hints trying to enforce unexecutable plans
 
-Planner chooses any executable plans when the enforced plan cannot be executed.
+In the case where hinting results in a plan that connect be executed, the planner may choose any executable plan. Examples of unexecutable plans include:
 
 -   `FULL OUTER JOIN` to use nested loop
 -   To use indexes that does not have columns used in quals
@@ -405,11 +406,11 @@ Planner chooses any executable plans when the enforced plan cannot be executed.
 
 #### Queries in ECPG
 
-ECPG removes comments in queries written as embedded SQLs so hints cannot be passed form those queries. The only exception is that `EXECUTE` command passes given string unmodifed. Please consider hint tables in the case.
+ECPG removes comments in queries written as embedded SQLs, so hints cannot be passed in those queries. The only exception is the `EXECUTE` command which passes a given string unmodifed. It is recommended to consider using hint tables in this scenario.
 
 #### Work with `pg_stat_statements`
 
-`pg_stat_statements` generates a query id ignoring comments. As the result, the identical queries with different hints are summarized as the same query.
+`pg_stat_statements` generates a query id ignoring comments. As a result, identical queries with different hints are summarized as the same query.
 
 ## Requirements
 
@@ -443,28 +444,28 @@ The available hints are listed below.
 |:-----------------------------|:--------------------------------------------------------------------------------------------------------------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Scan method                  | `SeqScan(table)`                                                                                                                  | Forces sequential scan on the table                                                                                                                                                                                                                                                                                                                      |
 |                              | `TidScan(table)`                                                                                                                  | Forces TID scan on the table.                                                                                                                                                                                                                                                                                                                            |
-|                              | `IndexScan(table[ index...])`                                                                                                     | Forces index scan on the table. Restricts to specified indexes if any.                                                                                                                                                                                                                                                                                   |
-|                              | `IndexOnlyScan(table[ index...])`                                                                                                 | Forces index only scan on the table. Rstricts to specfied indexes if any. Index scan may be used if index only scan is not available. Available for PostgreSQL 9.2 and later.                                                                                                                                                                            |
-|                              | `BitmapScan(table[ index...])`                                                                                                    | Forces bitmap scan on the table. Restoricts to specfied indexes if any.                                                                                                                                                                                                                                                                                  |
-|                              | `IndexScanRegexp(table[ POSIX Regexp...])` `IndexOnlyScanRegexp(table[ POSIX Regexp...])` `BitmapScanRegexp(table[ POSIX Regexp...])` | Forces index scan or index only scan (For PostgreSQL 9.2 and later) or bitmap scan on the table. Restricts to indexes that matches the specified POSIX regular expression pattern                                                                                                                                                                        |
+|                              | `IndexScan(table[ index...])`                                                                                                     | Forces index scan on the table. Restricted to specified indexes if any.                                                                                                                                                                                                                                                                                   |
+|                              | `IndexOnlyScan(table[ index...])`                                                                                                 | Forces index-only scan on the table. Restricted to specfied indexes if any. Index scan may be used if index-only scan is not available.                                                            |
+|                              | `BitmapScan(table[ index...])`                                                                                                    | Forces bitmap scan on the table. Restricted to specfied indexes if any.                                                                                                                                                                                                                                                                                  |
+|                              | `IndexScanRegexp(table[ POSIX Regexp...])` `IndexOnlyScanRegexp(table[ POSIX Regexp...])` `BitmapScanRegexp(table[ POSIX Regexp...])` | Forces index scan or index-only scan or bitmap scan on the table. Restricted to indexes that match the specified POSIX regular expression pattern.                                                                                                                                                                        |
 |                              | `NoSeqScan(table)`                                                                                                                | Forces not to do sequential scan on the table.                                                                                                                                                                                                                                                                                                           |
 |                              | `NoTidScan(table)`                                                                                                                | Forces not to do TID scan on the table.                                                                                                                                                                                                                                                                                                                  |
-|                              | `NoIndexScan(table)`                                                                                                              | Forces not to do index scan and index only scan (For PostgreSQL 9.2 and later) on the table.                                                                                                                                                                                                                                                             |
-|                              | `NoIndexOnlyScan(table)`                                                                                                          | Forces not to do index only scan on the table. Available for PostgreSQL 9.2 and later.                                                                                                                                                                                                                                                                   |
+|                              | `NoIndexScan(table)`                                                                                                              | Forces not to do index scan (or index-only scan) on the table.                                                                                                                                                                                                                                                             |
+|                              | `NoIndexOnlyScan(table)`                                                                                                          | Forces not to do index-only scan on the table.                                                                                                                                                                                                                                                                   |
 |                              | `NoBitmapScan(table)`                                                                                                             | Forces not to do bitmap scan on the table.                                                                                                                                                                                                                                                                                                               |
-| Join method                  | `NestLoop(table table[ table...])`                                                                                                | Forces nested loop for the joins consist of the specifiled tables.                                                                                                                                                                                                                                                                                       |
-|                              | `HashJoin(table table[ table...])`                                                                                                | Forces hash join for the joins consist of the specifiled tables.                                                                                                                                                                                                                                                                                         |
-|                              | `MergeJoin(table table[ table...])`                                                                                               | Forces merge join for the joins consist of the specifiled tables.                                                                                                                                                                                                                                                                                        |
-|                              | `NoNestLoop(table table[ table...])`                                                                                              | Forces not to do nested loop for the joins consist of the specifiled tables.                                                                                                                                                                                                                                                                             |
-|                              | `NoHashJoin(table table[ table...])`                                                                                              | Forces not to do hash join for the joins consist of the specifiled tables.                                                                                                                                                                                                                                                                               |
-|                              | `NoMergeJoin(table table[ table...])`                                                                                             | Forces not to do merge join for the joins consist of the specifiled tables.                                                                                                                                                                                                                                                                              |
+| Join method                  | `NestLoop(table table[ table...])`                                                                                                | Forces nested loop for the joins between the specifiled tables.                                                                                                                                                                                                                                                                                       |
+|                              | `HashJoin(table table[ table...])`                                                                                                | Forces hash join for the joins between the specifiled tables.                                                                                                                                                                                                                                                                                         |
+|                              | `MergeJoin(table table[ table...])`                                                                                               | Forces merge join for the joins between the specifiled tables.                                                                                                                                                                                                                                                                                        |
+|                              | `NoNestLoop(table table[ table...])`                                                                                              | Forces not to do nested loop for the joins between the specifiled tables.                                                                                                                                                                                                                                                                             |
+|                              | `NoHashJoin(table table[ table...])`                                                                                              | Forces not to do hash join for the joins between the specifiled tables.                                                                                                                                                                                                                                                                               |
+|                              | `NoMergeJoin(table table[ table...])`                                                                                             | Forces not to do merge join for the joins between the specifiled tables.                                                                                                                                                                                                                                                                              |
 | Join order                   | `Leading(table table[ table...])`                                                                                                 | Forces join order as specified.                                                                                                                                                                                                                                                                                                                          |
 |                              | `Leading(<join pair>)`                                                                                                            | Forces join order and directions as specified. A join pair is a pair of tables and/or other join pairs enclosed by parentheses, which can make a nested structure.                                                                                                                                                                                       |
-| Behavior control on Join     | `Memoize(table table[ table...])`                                                                                                 | Allow the topmost join of a join among the specified tables to memoize the inner result. (Note that this doesn't enforce.)                                                                                                                                                                                                                                                                                                              |
+| Behavior control on Join     | `Memoize(table table[ table...])`                                                                                                 | Allow the topmost join of a join among the specified tables to memoize the inner result. (Note this doesn't force, but only allows.)                                                                                                                                                                                                                                                                                                              |
 |                              | `NoMemoize(table table[ table...])`                                                                                               | Inhibit the topmost join of a join among the specified tables from memoizing the inner result.                                                                                                                                                                                                                                                                                                        |
-| Row number correction        | `Rows(table table[ table...] correction)`                                                                                         | Corrects row number of a result of the joins consist of the specfied tables. The available correction methods are absolute (#<n>), addition (+<n>), subtract (-<n>) and multiplication (*<n>). <n> should be a string that strtod() can read.                                                                                                            |
-| Parallel query configuration | `Parallel(table <# of workers> [soft\|hard])`                                                                                     | Enforce or inhibit parallel execution of specfied table. <# of workers> is the desired number of parallel workers, where zero means inhibiting parallel execution. If the third parameter is soft (default), it just changes max_parallel_workers_per_gather and leave everything else to planner. Hard means enforcing the specified number of workers. |
-| GUC                          | `Set(GUC-param value)`                                                                                                            | Set the GUC parameter to the value while planner is running.                                                                                                                                                                                                                                                                                             |
+| Row number correction        | `Rows(table table[ table...] correction)`                                                                                         | Modify row number estimate of the result of joins between the specfied tables. The available correction methods are absolute (#<n>), addition (+<n>), subtract (-<n>), or multiplication (*<n>). <n> should be a string that strtod() can read.                                                                                                            |
+| Parallel query configuration | `Parallel(table <# of workers> [soft\|hard])`                                                                                     | Enforce or inhibit parallel execution of specfied table. <# of workers> is the desired number of parallel workers, where zero means inhibiting parallel execution. If the third parameter is soft (default), it just changes max_parallel_workers_per_gather and leaves everything else to the planner. Hard means enforcing the specified number of workers. |
+| GUC                          | `Set(GUC-param value)`                                                                                                            | Set the GUC parameter to the value during plan time.                                                                                                                                                                                                                                                                                             |
 
 * * * * *
 

--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ The PostgreSQL optimizer uses a cost-based approach to determine the most effici
 
 ### Basic Usage
 
-`pg_hint_plan` reads hinting phrases in specially formulated comments given within the target SQL statement. The special form begins with the character sequence `"/\*+"` and ends with `"\*/"`. Hint phrases consist of a hint name followed parameters enclosed by parentheses and delimited by spaces. Hinting phrases may be delimited by new lines for readability.
+`pg_hint_plan` reads hinting phrases in specially formulated comments given within the target SQL statement. The special form begins with the character sequence `"/\*+"` and ends with `"\*/"`. Hint phrases consist of a hint name followed by parameters enclosed by parentheses and delimited by spaces. Hinting phrases may be delimited by new lines for readability.
 
-In the example below, hash join is selected as the joning method and scanning `pgbench_accounts` by sequential scan method.
+In the example below, hash join is selected as the joining method and scanning `pgbench_accounts` by sequential scan method.
 
 <pre>
 postgres=# /*+
@@ -78,7 +78,7 @@ The following example shows how to operate with the hint table.
     DELETE 1
     postgres=#
 
-The hint table is owned by and have the default privileges of the creating user at the time of creation during the `CREATE EXTENSION` command. Table hints are prioritized over comment hits.
+The hint table is owned by and has the default privileges of the creating user at the time of creation during the `CREATE EXTENSION` command. Table hints are prioritized over comment hits.
 
 ### The types of hints
 
@@ -104,7 +104,7 @@ Join method hints are only effective on ordinary tables, inheritance tables, UNL
 
 #### Hint for joining order
 
-This hint "Leading" enforces the order of joining on two or more tables. There are two ways of enforcing join order. One is enforcing the specific order of joining, but not restricting the direction at each join level. The other enfoces both join order and join direction. Additional details are available in the [hint list](#hints-list) table.
+This hint "Leading" enforces the order of joining on two or more tables. There are two ways of enforcing join order. One is enforcing the specific order of joining, but not restricting the direction at each join level. The other enforces both join order and join direction. Additional details are available in the [hint list](#hints-list) table.
 
     postgres=# /*+
     postgres*#     NestLoop(t1 t2)
@@ -126,7 +126,7 @@ This hint "Rows" modifies row number estimates for joins that come from the plan
 
 #### Hint for parallel plan
 
-This hint `Parallel` enforces parallel execution configuration on scans. The first and second parameter specifiy the table and number of workers to be used for the paralel scan. The third parameter specifies the strength of enfocement. `soft` means that `pg_hint_plan` only changes `max_parallel_worker_per_gather`, leaving all other parameters to the planner. `hard` changes other planner parameters so as to forcibly apply the number.
+This hint `Parallel` enforces parallel execution configuration on scans. The first and second parameter specifiy the table and number of workers to be used for the parallel scan. The third parameter specifies the strength of enfocement. `soft` means that `pg_hint_plan` only changes `max_parallel_worker_per_gather`, leaving all other parameters to the planner. `hard` changes other planner parameters so as to forcibly apply the number.
 
 Parallel plan hints can affect scans on ordinary tables, inheritence parents, unlogged tables, and system catalogs. External tables, table functions, values clause, CTEs, views, and subqueries are not affected. Note that the internal tables of a view can be specified by its real name/alias as the target object. The following example shows that the query is enforced differently on each table.
 
@@ -260,7 +260,7 @@ Use `CREATE EXTENSION` and `SET pg_hint_plan.enable_hint_tables TO on` if you wa
 
 #### Letter case in the object names
 
-Unlike the way PostgreSQL handles object names, `pg_hint_plan` compares bare object names in hints against the database internal object names and are case sensitive. Therefore an object name TBL in a hint matches only "TBL" in database and does not match any unquoted names in a query like TBL, tbl or Tbl.
+Unlike the way PostgreSQL handles object names, `pg_hint_plan` compares bare object names in hints against the database internal object names and are case sensitive. Therefore an object name TBL in a hint matches only "TBL" in the database and does not match any unquoted names in a query like TBL, tbl or Tbl.
 
 #### Escaping special chacaters in object names
 
@@ -268,7 +268,7 @@ The objects in a hint parameter should be enclosed by double quotes if they incl
 
 ### Distinction between multiple occurances of a table
 
-`pg_hint_plan` uses alises to identify the target objects, if present. This allows you to specificy a specific occurance of a table among multiple occurances. 
+`pg_hint_plan` uses aliases to identify the target objects, if present. This allows you to target a specific occurance of a table among multiple occurances.
 
     postgres=# /*+ HashJoin(t1 t1) */
     postgres-# EXPLAIN SELECT * FROM s1.t1
@@ -312,7 +312,7 @@ One multistatement can have only one hint block, however the included hints will
 
 #### VALUES expressions
 
-`VALUES` expressions in `FROM` clause are named as `*VALUES*` internally so it is hintable if it is the only `VALUES` in a query. Two or more `VALUES` expressions in a query seem distinguishable looking at its explain result, but in reality it is merely a cosmetic and they are not distinguishable.
+`VALUES` expressions in `FROM` clause are named as `*VALUES*` internally so it is hintable if it is the only `VALUES` in a query. Two or more `VALUES` expressions in a query seem distinguishable looking at its explain result, but in reality it is merely cosmetic and they are not distinguishable.
 
     postgres=# /*+ MergeJoin(*VALUES*_1 *VALUES*) */
           EXPLAIN SELECT * FROM (VALUES (1, 1), (2, 2)) v (a, b)
@@ -365,7 +365,7 @@ A `UNION` can run in parallel only when all underlying subqueries are parallel-s
 
 #### Setting `pg_hint_plan` parameters by Set hints
 
-`pg_hint_plan` parameters can change the behavior of `pg_hint_plan` itself, which may case some parameters to not work as expected.
+`pg_hint_plan` parameters can change the behavior of `pg_hint_plan` itself, which may cause some parameters to not work as expected.
 
 -   Hints to change `enable_hint`, `enable_hint_tables` are ignored even though they are reported as "used hints" in debug logs.
 -   Setting `debug_print` and `message_level` works from midst of the processing of the target query.
@@ -463,7 +463,7 @@ The available hints are listed below.
 |                              | `Leading(<join pair>)`                                                                                                            | Forces join order and directions as specified. A join pair is a pair of tables and/or other join pairs enclosed by parentheses, which can make a nested structure.                                                                                                                                                                                       |
 | Behavior control on Join     | `Memoize(table table[ table...])`                                                                                                 | Allow the topmost join of a join among the specified tables to memoize the inner result. (Note this doesn't force, but only allows.)                                                                                                                                                                                                                                                                                                              |
 |                              | `NoMemoize(table table[ table...])`                                                                                               | Inhibit the topmost join of a join among the specified tables from memoizing the inner result.                                                                                                                                                                                                                                                                                                        |
-| Row number correction        | `Rows(table table[ table...] correction)`                                                                                         | Modify row number estimate of the result of joins between the specfied tables. The available correction methods are absolute (#<n>), addition (+<n>), subtract (-<n>), or multiplication (*<n>). <n> should be a string that strtod() can read.                                                                                                            |
+| Row number correction        | `Rows(table table[ table...] correction)`                                                                                         | Modify row number estimate of the result of joins between the specfied tables. The available methods are absolute (#<n>), addition (+<n>), subtraction (-<n>), or multiplication (*<n>). <n> should be a string that strtod() can read.                                                                                                            |
 | Parallel query configuration | `Parallel(table <# of workers> [soft\|hard])`                                                                                     | Enforce or inhibit parallel execution of specfied table. <# of workers> is the desired number of parallel workers, where zero means inhibiting parallel execution. If the third parameter is soft (default), it just changes max_parallel_workers_per_gather and leaves everything else to the planner. Hard means enforcing the specified number of workers. |
 | GUC                          | `Set(GUC-param value)`                                                                                                            | Set the GUC parameter to the value during plan time.                                                                                                                                                                                                                                                                                             |
 


### PR DESCRIPTION
These changes include fixing a number of typos, some syntax errors in the examples, and a fair amount of wordsmithing for clarification and/or grammar improvements.