### PR TITLE
Add lexer to handle query parsing for hints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ regression.*
 /tmp_check/
 /RPMS/
 
+# Generated files
+/query_scan.c
+
 # Documentation artifacts
 docs/_build
 docs/locale/**/*.mo

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,12 @@
 # Copyright (c) 2012-2023, NIPPON TELEGRAPH AND TELEPHONE CORPORATION
 #
 
-MODULES = pg_hint_plan
+MODULE_big = pg_hint_plan
+OBJS = \
+	$(WIN32RES) \
+	pg_hint_plan.o \
+	query_scan.o
+
 HINTPLANVER = 1.7.0
 
 REGRESS = init base_plan pg_hint_plan ut-init ut-A ut-S ut-J ut-L ut-G ut-R \

--- a/expected/pg_hint_plan.out
+++ b/expected/pg_hint_plan.out
@@ -109,7 +109,7 @@ EXPLAIN (COSTS false) SELECT * FROM t1, t2 WHERE t1.val = t2.val;
 
 /*+ Test (t1 t2) */
 EXPLAIN (COSTS false) SELECT * FROM t1, t2 WHERE t1.id = t2.id;
-INFO:  pg_hint_plan: hint syntax error at or near "Test (t1 t2) "
+INFO:  pg_hint_plan: hint syntax error at or near " Test (t1 t2) "
 DETAIL:  Unrecognized hint keyword "Test".
               QUERY PLAN              
 --------------------------------------
@@ -153,16 +153,23 @@ EXPLAIN (COSTS false) SELECT * FROM t1, t2 WHERE t1.id = t2.id;
 
 /*+Set(enable_indexscan off) /* nest comment */ */
 EXPLAIN (COSTS false) SELECT * FROM t1, t2 WHERE t1.id = t2.id;
-INFO:  pg_hint_plan: hint syntax error at or near "/* nest comment */ */
-EXPLAIN (COSTS false) SELECT * FROM t1, t2 WHERE t1.id = t2.id;"
+INFO:  pg_hint_plan: hint syntax error at or near "/*"
 DETAIL:  Nested block comments are not supported.
-              QUERY PLAN              
---------------------------------------
- Merge Join
-   Merge Cond: (t1.id = t2.id)
-   ->  Index Scan using t1_pkey on t1
-   ->  Index Scan using t2_pkey on t2
-(4 rows)
+LOG:  pg_hint_plan:
+used hint:
+Set(enable_indexscan off)
+not used hint:
+duplication hint:
+error hint:
+
+          QUERY PLAN          
+------------------------------
+ Hash Join
+   Hash Cond: (t1.id = t2.id)
+   ->  Seq Scan on t1
+   ->  Hash
+         ->  Seq Scan on t2
+(5 rows)
 
 /*+Set(enable_indexscan off)*/
 EXPLAIN (COSTS false) SELECT * FROM t1, t2 WHERE t1.id = t2.id;
@@ -9048,7 +9055,7 @@ Rows(t1 t2 /99)
 \o results/pg_hint_plan.tmpout
 /*+ Rows(t1 t2 -99999) */
 EXPLAIN SELECT * FROM t1 JOIN t2 ON (t1.id = t2.id);
-WARNING:  Force estimate to be at least one row, to avoid possible divide-by-zero when interpolating costs : Rows(t1 t2 -99999) 
+WARNING:  Force estimate to be at least one row, to avoid possible divide-by-zero when interpolating costs :  Rows(t1 t2 -99999) 
 LOG:  pg_hint_plan:
 used hint:
 Rows(t1 t2 -99999)

--- a/expected/ut-A.out
+++ b/expected/ut-A.out
@@ -115,18 +115,32 @@ error hint:
 
 -- No. A-5-2-3
 EXPLAIN (COSTS false) SELECT c1 AS "c1"/*+SeqScan(t1)*/ FROM s1.t1 WHERE t1.c1 = 1;
-            QUERY PLAN             
------------------------------------
- Index Only Scan using t1_i1 on t1
-   Index Cond: (c1 = 1)
+LOG:  pg_hint_plan:
+used hint:
+SeqScan(t1)
+not used hint:
+duplication hint:
+error hint:
+
+     QUERY PLAN     
+--------------------
+ Seq Scan on t1
+   Filter: (c1 = 1)
 (2 rows)
 
 -- No. A-5-2-4
 EXPLAIN (COSTS false) SELECT * /*+SeqScan(t1)*/ FROM s1.t1 WHERE t1.c1 = 1;
-          QUERY PLAN          
-------------------------------
- Index Scan using t1_i1 on t1
-   Index Cond: (c1 = 1)
+LOG:  pg_hint_plan:
+used hint:
+SeqScan(t1)
+not used hint:
+duplication hint:
+error hint:
+
+     QUERY PLAN     
+--------------------
+ Seq Scan on t1
+   Filter: (c1 = 1)
 (2 rows)
 
 ----
@@ -1399,9 +1413,17 @@ error hint:
 -- No. A-9-2-11
 /*+SeqScan(/**/)*/
 EXPLAIN (COSTS false) SELECT * FROM s1.t1 "/**/" WHERE "/**/".c1 = 1;
-INFO:  pg_hint_plan: hint syntax error at or near "/**/)*/
-EXPLAIN (COSTS false) SELECT * FROM s1.t1 "/**/" WHERE "/**/".c1 = 1;"
+INFO:  pg_hint_plan: hint syntax error at or near "/**/"
 DETAIL:  Nested block comments are not supported.
+INFO:  pg_hint_plan: hint syntax error at or near ""
+DETAIL:  SeqScan hint requires a relation.
+LOG:  pg_hint_plan:
+used hint:
+not used hint:
+duplication hint:
+error hint:
+SeqScan()
+
              QUERY PLAN              
 -------------------------------------
  Index Scan using t1_i1 on t1 "/**/"
@@ -1410,9 +1432,21 @@ DETAIL:  Nested block comments are not supported.
 
 /*+SeqScan(/**//**//**/)*/
 EXPLAIN (COSTS false) SELECT * FROM s1.t1 "/**//**//**/" WHERE "/**//**//**/".c1 = 1;
-INFO:  pg_hint_plan: hint syntax error at or near "/**//**//**/)*/
-EXPLAIN (COSTS false) SELECT * FROM s1.t1 "/**//**//**/" WHERE "/**//**//**/".c1 = 1;"
+INFO:  pg_hint_plan: hint syntax error at or near "/**//**//**/"
 DETAIL:  Nested block comments are not supported.
+INFO:  pg_hint_plan: hint syntax error at or near "/**//**/"
+DETAIL:  Nested block comments are not supported.
+INFO:  pg_hint_plan: hint syntax error at or near "/**/"
+DETAIL:  Nested block comments are not supported.
+INFO:  pg_hint_plan: hint syntax error at or near ""
+DETAIL:  SeqScan hint requires a relation.
+LOG:  pg_hint_plan:
+used hint:
+not used hint:
+duplication hint:
+error hint:
+SeqScan()
+
                  QUERY PLAN                  
 ---------------------------------------------
  Index Scan using t1_i1 on t1 "/**//**//**/"
@@ -1426,11 +1460,16 @@ Set/**/あ")*/
 EXPLAIN (COSTS false) SELECT * FROM s1.t1 "tT()"" 	
 Set/**/あ" WHERE "tT()"" 	
 Set/**/あ".c1 = 1;
-INFO:  pg_hint_plan: hint syntax error at or near "/**/あ")*/
-EXPLAIN (COSTS false) SELECT * FROM s1.t1 "tT()"" 	
-Set/**/あ" WHERE "tT()"" 	
-Set/**/あ".c1 = 1;"
+INFO:  pg_hint_plan: hint syntax error at or near "/**/"
 DETAIL:  Nested block comments are not supported.
+LOG:  pg_hint_plan:
+used hint:
+not used hint:
+SeqScan("tT()"" 	
+Setあ")
+duplication hint:
+error hint:
+
                 QUERY PLAN                
 ------------------------------------------
  Index Scan using t1_i1 on t1 "tT()""    
@@ -1602,13 +1641,22 @@ error hint:
 -- No. A-7-4-7
 /*+Set(enable_indexscan off)Set(enable_tidscan /* value */off)Set(enable_bitmapscan off)SeqScan(t1)*/
 EXPLAIN (COSTS false) SELECT * FROM s1.t1 WHERE t1.c1 = 1;
-INFO:  pg_hint_plan: hint syntax error at or near "/* value */off)Set(enable_bitmapscan off)SeqScan(t1)*/
-EXPLAIN (COSTS false) SELECT * FROM s1.t1 WHERE t1.c1 = 1;"
+INFO:  pg_hint_plan: hint syntax error at or near "/*"
 DETAIL:  Nested block comments are not supported.
-          QUERY PLAN          
-------------------------------
- Index Scan using t1_i1 on t1
-   Index Cond: (c1 = 1)
+LOG:  pg_hint_plan:
+used hint:
+SeqScan(t1)
+Set(enable_bitmapscan off)
+Set(enable_indexscan off)
+Set(enable_tidscan off)
+not used hint:
+duplication hint:
+error hint:
+
+     QUERY PLAN     
+--------------------
+ Seq Scan on t1
+   Filter: (c1 = 1)
 (2 rows)
 
 ----

--- a/expected/ut-J.out
+++ b/expected/ut-J.out
@@ -3771,7 +3771,7 @@ INFO:  pg_hint_plan: hint syntax error at or near "HashJoin(*VALUES* t3 t2)Merge
 DETAIL:  Relation name "*VALUES*" is ambiguous.
 INFO:  pg_hint_plan: hint syntax error at or near "MergeJoin(*VALUES* t3 t2 t1)"
 DETAIL:  Relation name "*VALUES*" is ambiguous.
-INFO:  pg_hint_plan: hint syntax error at or near "Leading(*VALUES* t3 t2 t1) NestLoop(t4 t3)HashJoin(*VALUES* t3 t2)MergeJoin(*VALUES* t3 t2 t1)"
+INFO:  pg_hint_plan: hint syntax error at or near " Leading(*VALUES* t3 t2 t1) NestLoop(t4 t3)HashJoin(*VALUES* t3 t2)MergeJoin(*VALUES* t3 t2 t1)"
 DETAIL:  Relation name "*VALUES*" is ambiguous.
 LOG:  pg_hint_plan:
 used hint:

--- a/expected/ut-L.out
+++ b/expected/ut-L.out
@@ -3591,7 +3591,7 @@ error hint:
 
 /*+ Leading(*VALUES* t3 t2 t1) */
 EXPLAIN (COSTS false) SELECT * FROM s1.t1, s1.t2, (VALUES(1,1,1,'1'), (2,2,2,'2')) AS t3 (c1, c2, c3, c4), (VALUES(1,1,1,'1'), (2,2,2,'2')) AS t4 (c1, c2, c3, c4) WHERE t1.c1 = t2.c1 AND t1.c1 = t3.c1 AND t1.c1 = t4.c1;
-INFO:  pg_hint_plan: hint syntax error at or near "Leading(*VALUES* t3 t2 t1) "
+INFO:  pg_hint_plan: hint syntax error at or near " Leading(*VALUES* t3 t2 t1) "
 DETAIL:  Relation name "*VALUES*" is ambiguous.
 LOG:  pg_hint_plan:
 used hint:

--- a/expected/ut-R.out
+++ b/expected/ut-R.out
@@ -4237,7 +4237,7 @@ INFO:  pg_hint_plan: hint syntax error at or near "Rows(*VALUES* t3 t2 #2)Rows(*
 DETAIL:  Relation name "*VALUES*" is ambiguous.
 INFO:  pg_hint_plan: hint syntax error at or near "Rows(*VALUES* t3 t2 t1 #2)"
 DETAIL:  Relation name "*VALUES*" is ambiguous.
-INFO:  pg_hint_plan: hint syntax error at or near "Leading(*VALUES* t3 t2 t1) Rows(t4 t3 #2)Rows(*VALUES* t3 t2 #2)Rows(*VALUES* t3 t2 t1 #2)"
+INFO:  pg_hint_plan: hint syntax error at or near " Leading(*VALUES* t3 t2 t1) Rows(t4 t3 #2)Rows(*VALUES* t3 t2 #2)Rows(*VALUES* t3 t2 t1 #2)"
 DETAIL:  Relation name "*VALUES*" is ambiguous.
 LOG:  pg_hint_plan:
 used hint:

--- a/query_scan.h
+++ b/query_scan.h
@@ -1,0 +1,40 @@
+/*-------------------------------------------------------------------------
+ *
+ * query_scan.h
+ *	  lexical scanner for SQL commands
+ *
+ * This lexer can be used to extra hints from query contents, taking into
+ * account what the backend would consider as values, for example.
+ *
+ * Portions Copyright (c) 1996-2023, PostgreSQL Global Development Group
+ * Portions Copyright (c) 1994, Regents of the University of California
+ *
+ * query_scan.h
+ *
+ *-------------------------------------------------------------------------
+ */
+#ifndef QUERY_SCAN_H
+#define QUERY_SCAN_H
+
+#include "lib/stringinfo.h"
+
+/* Abstract type for lexer's internal state */
+typedef struct QueryScanStateData *QueryScanState;
+
+/* Termination states for query_scan() */
+typedef enum
+{
+	QUERY_SCAN_INCOMPLETE,			/* end of line, SQL statement incomplete */
+	QUERY_SCAN_EOL					/* end of line, SQL possibly complete */
+} QueryScanResult;
+
+extern QueryScanState query_scan_create(void);
+extern void query_scan_setup(QueryScanState state,
+							 const char *line, int line_len,
+							 int encoding, bool std_strings,
+							 int elevel);
+extern void query_scan_finish(QueryScanState state);
+extern QueryScanResult query_scan(QueryScanState state,
+								  StringInfo query_buf);
+
+#endif							/* QUERY_SCAN_H */

--- a/query_scan.l
+++ b/query_scan.l
@@ -1,0 +1,1154 @@
+%top{
+/*-------------------------------------------------------------------------
+ *
+ * query_scan.l
+ *	  lexical scanner for SQL commands
+ *
+ * This code is mainly concerned with determining where query hints are
+ * located and where the end of a SQL statement is: we are looking for
+ * semicolons that are not within quotes, comments, or parentheses.
+ * The most reliable way to handle this is to borrow the backend's flex
+ * lexer rules, lock, stock, and barrel.  The rules below are (except for
+ * a few) the same as the backend's, but their actions are just ECHO
+ * whereas the backend's actions generally do other things.
+ *
+ * XXX The rules in this file must be kept in sync with the backend lexer!!!
+ *
+ * XXX Avoid creating backtracking cases --- see the backend lexer for info.
+ *
+ * See query_scan_int.h for additional details.
+ *
+ * Portions Copyright (c) 1996-2023, PostgreSQL Global Development Group
+ * Portions Copyright (c) 1994, Regents of the University of California
+ *
+ * IDENTIFICATION
+ *	  query_scan.l
+ *
+ *-------------------------------------------------------------------------
+ */
+#include "postgres.h"
+
+#include "query_scan.h"
+#include "mb/pg_wchar.h"
+
+#include "query_scan_int.h"
+
+}
+
+%{
+/* Avoid exit() on fatal scanner errors (a bit ugly -- see yy_fatal_error) */
+#undef fprintf
+#define fprintf(file, fmt, msg)  fprintf_to_ereport(fmt, msg)
+
+static void
+fprintf_to_ereport(const char *fmt, const char *msg)
+{
+	ereport(ERROR, (errmsg_internal("%s", msg)));
+}
+
+/*
+ * We must have a typedef YYSTYPE for yylex's first argument, but this lexer
+ * doesn't presently make use of that argument, so just declare it as int.
+ */
+typedef int YYSTYPE;
+
+/*
+ * Set the type of yyextra; we use it as a pointer back to the containing
+ * QueryScanState.
+ */
+#define YY_EXTRA_TYPE QueryScanState
+
+/* Return values from yylex() */
+#define LEXRES_EOL			0	/* end of input */
+
+#define ECHO query_scan_emit(cur_state, yytext, yyleng)
+
+%}
+
+%option reentrant
+%option bison-bridge
+%option 8bit
+%option never-interactive
+%option nodefault
+%option noinput
+%option nounput
+%option noyywrap
+%option warn
+%option prefix="query_yy"
+
+/*
+ * All of the following definitions and rules should exactly match with
+ * upstream PostgreSQL's src/backend/parser/scan.l so far as the flex
+ * patterns are concerned.  The rule bodies are just ECHO as opposed to what
+ * the backend does, however.  (But be sure to duplicate code that affects
+ * the lexing process, such as BEGIN() and yyless().)
+ */
+
+/*
+ * OK, here is a short description of lex/flex rules behavior.
+ * The longest pattern which matches an input string is always chosen.
+ * For equal-length patterns, the first occurring in the rules list is chosen.
+ * INITIAL is the starting state, to which all non-conditional rules apply.
+ * Exclusive states change parsing rules while the state is active.  When in
+ * an exclusive state, only those rules defined for that state apply.
+ *
+ * We use exclusive states for quoted strings, extended comments,
+ * and to eliminate parsing troubles for numeric strings.
+ * Exclusive states:
+ *  <xb> bit string literal
+ *  <xc> extended C-style comments
+ *  <xd> delimited identifiers (double-quoted identifiers)
+ *  <xh> hexadecimal byte string
+ *  <xhint> Query hints as C-style comments
+ *  <xq> standard quoted strings
+ *  <xqs> quote stop (detect continued strings)
+ *  <xe> extended quoted strings (support backslash escape sequences)
+ *  <xdolq> $foo$ quoted strings
+ *  <xui> quoted identifier with Unicode escapes
+ *  <xus> quoted string with Unicode escapes
+ *
+ * Note: we intentionally don't mimic the backend's <xeu> state; we have
+ * no need to distinguish it from <xe> state, and no good way to get out
+ * of it in error cases.  The backend just throws yyerror() in those
+ * cases, but that's not an option here.
+ */
+
+%x xb
+%x xc
+%x xd
+%x xh
+%x xhint
+%x xq
+%x xqs
+%x xe
+%x xdolq
+%x xui
+%x xus
+
+/*
+ * In order to make the world safe for Windows and Mac clients as well as
+ * Unix ones, we accept either \n or \r as a newline.  A DOS-style \r\n
+ * sequence will be seen as two successive newlines, but that doesn't cause
+ * any problems.  Comments that start with -- and extend to the next
+ * newline are treated as equivalent to a single whitespace character.
+ *
+ * NOTE a fine point: if there is no newline following --, we will absorb
+ * everything to the end of the input as a comment.  This is correct.  Older
+ * versions of Postgres failed to recognize -- as a comment if the input
+ * did not end with a newline.
+ *
+ * non_newline_space tracks all the other space characters except newlines.
+ *
+ * XXX if you change the set of whitespace characters, fix scanner_isspace()
+ * to agree.
+ */
+
+space			[ \t\n\r\f\v]
+non_newline_space	[ \t\f\v]
+newline			[\n\r]
+non_newline		[^\n\r]
+
+comment			("--"{non_newline}*)
+
+whitespace		({space}+|{comment})
+
+/*
+ * SQL requires at least one newline in the whitespace separating
+ * string literals that are to be concatenated.  Silly, but who are we
+ * to argue?  Note that {whitespace_with_newline} should not have * after
+ * it, whereas {whitespace} should generally have a * after it...
+ */
+
+special_whitespace		({space}+|{comment}{newline})
+non_newline_whitespace		({non_newline_space}|{comment})
+whitespace_with_newline	({non_newline_whitespace}*{newline}{special_whitespace}*)
+
+quote			'
+/* If we see {quote} then {quotecontinue}, the quoted string continues */
+quotecontinue	{whitespace_with_newline}{quote}
+
+/*
+ * {quotecontinuefail} is needed to avoid lexer backup when we fail to match
+ * {quotecontinue}.  It might seem that this could just be {whitespace}*,
+ * but if there's a dash after {whitespace_with_newline}, it must be consumed
+ * to see if there's another dash --- which would start a {comment} and thus
+ * allow continuation of the {quotecontinue} token.
+ */
+quotecontinuefail	{whitespace}*"-"?
+
+/* Bit string
+ * It is tempting to scan the string for only those characters
+ * which are allowed. However, this leads to silently swallowed
+ * characters if illegal characters are included in the string.
+ * For example, if xbinside is [01] then B'ABCD' is interpreted
+ * as a zero-length string, and the ABCD' is lost!
+ * Better to pass the string forward and let the input routines
+ * validate the contents.
+ */
+xbstart			[bB]{quote}
+xbinside		[^']*
+
+/* Hexadecimal byte string */
+xhstart			[xX]{quote}
+xhinside		[^']*
+
+/* National character */
+xnstart			[nN]{quote}
+
+/* Quoted string that allows backslash escapes */
+xestart			[eE]{quote}
+xeinside		[^\\']+
+xeescape		[\\][^0-7]
+xeoctesc		[\\][0-7]{1,3}
+xehexesc		[\\]x[0-9A-Fa-f]{1,2}
+xeunicode		[\\](u[0-9A-Fa-f]{4}|U[0-9A-Fa-f]{8})
+xeunicodefail	[\\](u[0-9A-Fa-f]{0,3}|U[0-9A-Fa-f]{0,7})
+
+/* Extended quote
+ * xqdouble implements embedded quote, ''''
+ */
+xqstart			{quote}
+xqdouble		{quote}{quote}
+xqinside		[^']+
+
+/* $foo$ style quotes ("dollar quoting")
+ * The quoted string starts with $foo$ where "foo" is an optional string
+ * in the form of an identifier, except that it may not contain "$",
+ * and extends to the first occurrence of an identical string.
+ * There is *no* processing of the quoted text.
+ *
+ * {dolqfailed} is an error rule to avoid scanner backup when {dolqdelim}
+ * fails to match its trailing "$".
+ */
+dolq_start		[A-Za-z\200-\377_]
+dolq_cont		[A-Za-z\200-\377_0-9]
+dolqdelim		\$({dolq_start}{dolq_cont}*)?\$
+dolqfailed		\${dolq_start}{dolq_cont}*
+dolqinside		[^$]+
+
+/* Double quote
+ * Allows embedded spaces and other special characters into identifiers.
+ */
+dquote			\"
+xdstart			{dquote}
+xdstop			{dquote}
+xddouble		{dquote}{dquote}
+xdinside		[^"]+
+
+/* Quoted identifier with Unicode escapes */
+xuistart		[uU]&{dquote}
+
+/* Quoted string with Unicode escapes */
+xusstart		[uU]&{quote}
+
+/* error rule to avoid backup */
+xufailed		[uU]&
+
+/*
+ * Query hints as C-style comments
+ *
+ * This should take priority to C-style comments, while the inside and end
+ * can match the rules cited below.
+ */
+xhintstart \/\*\+
+
+/* C-style comments
+ *
+ * The "extended comment" syntax closely resembles allowable operator syntax.
+ * The tricky part here is to get lex to recognize a string starting with
+ * slash-star as a comment, when interpreting it as an operator would produce
+ * a longer match --- remember lex will prefer a longer match!  Also, if we
+ * have something like plus-slash-star, lex will think this is a 3-character
+ * operator whereas we want to see it as a + operator and a comment start.
+ * The solution is two-fold:
+ * 1. append {op_chars}* to xcstart so that it matches as much text as
+ *    {operator} would. Then the tie-breaker (first matching rule of same
+ *    length) ensures xcstart wins.  We put back the extra stuff with yyless()
+ *    in case it contains a star-slash that should terminate the comment.
+ * 2. In the operator rule, check for slash-star within the operator, and
+ *    if found throw it back with yyless().  This handles the plus-slash-star
+ *    problem.
+ * Dash-dash comments have similar interactions with the operator rule.
+ */
+xcstart			\/\*{op_chars}*
+xcstop			\*+\/
+xcinside		[^*/]+
+
+ident_start		[A-Za-z\200-\377_]
+ident_cont		[A-Za-z\200-\377_0-9\$]
+
+identifier		{ident_start}{ident_cont}*
+
+/* Assorted special-case operators and operator-like tokens */
+typecast		"::"
+dot_dot			\.\.
+colon_equals	":="
+
+/*
+ * These operator-like tokens (unlike the above ones) also match the {operator}
+ * rule, which means that they might be overridden by a longer match if they
+ * are followed by a comment start or a + or - character. Accordingly, if you
+ * add to this list, you must also add corresponding code to the {operator}
+ * block to return the correct token in such cases. (This is not needed in
+ * query_scan.l since the token value is ignored there.)
+ */
+equals_greater	"=>"
+less_equals		"<="
+greater_equals	">="
+less_greater	"<>"
+not_equals		"!="
+
+/*
+ * "self" is the set of chars that should be returned as single-character
+ * tokens.  "op_chars" is the set of chars that can make up "Op" tokens,
+ * which can be one or more characters long (but if a single-char token
+ * appears in the "self" set, it is not to be returned as an Op).  Note
+ * that the sets overlap, but each has some chars that are not in the other.
+ *
+ * If you change either set, adjust the character lists appearing in the
+ * rule for "operator"!
+ */
+self			[,()\[\].;\:\+\-\*\/\%\^\<\>\=]
+op_chars		[\~\!\@\#\^\&\|\`\?\+\-\*\/\%\<\>\=]
+operator		{op_chars}+
+
+/*
+ * Numbers
+ *
+ * Unary minus is not part of a number here.  Instead we pass it separately to
+ * the parser, and there it gets coerced via doNegate().
+ *
+ * {numericfail} is used because we would like "1..10" to lex as 1, dot_dot, 10.
+ *
+ * {realfail} is added to prevent the need for scanner
+ * backup when the {real} rule fails to match completely.
+ */
+decdigit		[0-9]
+hexdigit		[0-9A-Fa-f]
+octdigit		[0-7]
+bindigit		[0-1]
+
+decinteger		{decdigit}(_?{decdigit})*
+hexinteger		0[xX](_?{hexdigit})+
+octinteger		0[oO](_?{octdigit})+
+bininteger		0[bB](_?{bindigit})+
+
+hexfail			0[xX]_?
+octfail			0[oO]_?
+binfail			0[bB]_?
+
+numeric			(({decinteger}\.{decinteger}?)|(\.{decinteger}))
+numericfail		{decdigit}+\.\.
+
+real			({decinteger}|{numeric})[Ee][-+]?{decinteger}
+realfail		({decinteger}|{numeric})[Ee][-+]
+
+decinteger_junk	{decinteger}{ident_start}
+hexinteger_junk	{hexinteger}{ident_start}
+octinteger_junk	{octinteger}{ident_start}
+bininteger_junk	{bininteger}{ident_start}
+numeric_junk	{numeric}{ident_start}
+real_junk		{real}{ident_start}
+
+param			\${decinteger}
+param_junk		\${decinteger}{ident_start}
+
+other			.
+
+/*
+ * Dollar quoted strings are totally opaque, and no escaping is done on them.
+ * Other quoted strings must allow some special characters such as single-quote
+ *  and newline.
+ * Embedded single-quotes are implemented both in the SQL standard
+ *  style of two adjacent single quotes "''" and in the Postgres/Java style
+ *  of escaped-quote "\'".
+ * Other embedded escaped characters are matched explicitly and the leading
+ *  backslash is dropped from the string.
+ * Note that xcstart must appear before operator, as explained above!
+ *  Also whitespace (comment) must appear before operator.
+ */
+
+%%
+
+%{
+		/* Declare some local variables inside yylex(), for convenience */
+		QueryScanState cur_state = yyextra;
+
+		/*
+		 * Force flex into the state indicated by start_state.  This has a
+		 * couple of purposes: it lets some of the functions below set a new
+		 * starting state without ugly direct access to flex variables, and it
+		 * allows us to transition from one flex lexer to another so that we
+		 * can lex different parts of the source string using separate lexers.
+		 */
+		BEGIN(cur_state->start_state);
+%}
+
+{whitespace}			{
+					/*
+					 * Note that the whitespace rule includes both true
+					 * whitespace and single-line ("--" style) comments.
+					 * We suppress whitespace until we have collected some
+					 * non-whitespace data.  (This interacts with some
+					 * decisions in MainLoop(); see there for details.)
+					 */
+				}
+
+{xhintstart}			{
+					/* Fail hard if there are more than one hint */
+					if (cur_state->xhintnum > 0)
+						query_yyerror(ERROR,
+							      yytext,
+							      "Multiple hints are not supported.");\
+
+					/*
+					 * Increment the hint counter as well as the comment
+					 * to be able to correctly ignore the contents in
+					 * nested contents.
+					 */
+					(cur_state->xhintnum)++;
+					(cur_state->xcdepth)++;
+					/* Put back any characters past slash-star-plus; see above */
+					yyless(3);
+					BEGIN(xhint);
+}
+
+<xhint>{
+{xcstart}			{
+					(cur_state->xcdepth)++;
+					query_yyerror(cur_state->elevel,
+						      yytext,
+						      "Nested block comments are not supported.");
+					/* Put back any characters past slash-star; see above */
+					yyless(2);
+				}
+{xcinside}			{
+					/*
+					 * Print the contents of the hint into the output buffer.
+					 * Ignore if we are in a comment.
+					 */
+					if (cur_state->xcdepth == 1)
+						ECHO;
+				}
+{xcstop}			{
+					if (cur_state->xcdepth > 0)
+						(cur_state->xcdepth)--;
+
+					if (cur_state->xcdepth <= 0)
+						BEGIN(INITIAL);
+				}
+{op_chars}			{
+					/* Special set of characters that can be authorized in hints */
+					if (cur_state->xcdepth == 1)
+						ECHO;
+				}
+
+\*+				{
+					/* Special character that can be authorized in hints */
+					if (cur_state->xcdepth == 1)
+						ECHO;
+				}
+} /* <xhint> */
+
+{xcstart}			{
+					cur_state->xcdepth = 0;
+					BEGIN(xc);
+					/* Put back any characters past slash-star; see above */
+					yyless(2);
+					/* ignore */
+				}
+
+<xc>{
+{xcstart}			{
+					(cur_state->xcdepth)++;
+					BEGIN(xc);
+					/* Put back any characters past slash-star; see above */
+					yyless(2);
+					/* ignore */
+				}
+
+{xcstop}			{
+					if (cur_state->xcdepth <= 0)
+						BEGIN(INITIAL);
+					else
+						(cur_state->xcdepth)--;
+					/* ignore */
+				}
+
+{xcinside}			{
+					/* ignore */
+				}
+
+{op_chars}			{
+					/* ignore */
+				}
+
+\*+				{
+					/* ignore */
+				}
+} /* <xc> */
+
+{xbstart}		{
+					BEGIN(xb);
+					/* ignore */
+				}
+<xh>{xhinside}	|
+<xb>{xbinside}	{
+					/* ignore */
+				}
+
+{xhstart}		{
+					/* Hexadecimal bit type.
+					 * At some point we should simply pass the string
+					 * forward to the parser and label it there.
+					 * In the meantime, place a leading "x" on the string
+					 * to mark it for the input routine as a hex string.
+					 */
+					BEGIN(xh);
+					/* ignore */
+				}
+
+{xnstart}		{
+					yyless(1);	/* eat only 'n' this time */
+					/* ignore */
+				}
+
+{xqstart}		{
+					if (cur_state->std_strings)
+						BEGIN(xq);
+					else
+						BEGIN(xe);
+					/* ignore */
+				}
+{xestart}		{
+					BEGIN(xe);
+					/* ignore */
+				}
+{xusstart}		{
+					BEGIN(xus);
+					/* ignore */
+				}
+
+<xb,xh,xq,xe,xus>{quote} {
+					/*
+					 * When we are scanning a quoted string and see an end
+					 * quote, we must look ahead for a possible continuation.
+					 * If we don't see one, we know the end quote was in fact
+					 * the end of the string.  To reduce the lexer table size,
+					 * we use a single "xqs" state to do the lookahead for all
+					 * types of strings.
+					 */
+					cur_state->state_before_str_stop = YYSTATE;
+					BEGIN(xqs);
+					/* ignore */
+				}
+<xqs>{quotecontinue} {
+					/*
+					 * Found a quote continuation, so return to the in-quote
+					 * state and continue scanning the literal.  Nothing is
+					 * added to the literal's contents.
+					 */
+					BEGIN(cur_state->state_before_str_stop);
+					/* ignore */
+				}
+<xqs>{quotecontinuefail} |
+<xqs>{other}	{
+					/*
+					 * Failed to see a quote continuation.  Throw back
+					 * everything after the end quote, and handle the string
+					 * according to the state we were in previously.
+					 */
+					yyless(0);
+					BEGIN(INITIAL);
+					/* There's nothing to echo ... */
+				}
+
+<xq,xe,xus>{xqdouble} {
+					/* ignore */
+				}
+<xq,xus>{xqinside}  {
+					/* ignore */
+				}
+<xe>{xeinside}  {
+					/* ignore */
+				}
+<xe>{xeunicode} {
+					/* ignore */
+				}
+<xe>{xeunicodefail}	{
+					/* ignore */
+				}
+<xe>{xeescape}  {
+					/* ignore */
+				}
+<xe>{xeoctesc}  {
+					/* ignore */
+				}
+<xe>{xehexesc}  {
+					/* ignore */
+				}
+<xe>.			{
+					/* This is only needed for \ just before EOF */
+					/* ignore */
+				}
+
+{dolqdelim}		{
+					cur_state->dolqstart = pstrdup(yytext);
+					BEGIN(xdolq);
+					/* ignore */
+				}
+{dolqfailed}	{
+					/* throw back all but the initial "$" */
+					yyless(1);
+					/* ignore */
+				}
+<xdolq>{dolqdelim} {
+					if (strcmp(yytext, cur_state->dolqstart) == 0)
+					{
+						pfree(cur_state->dolqstart);
+						cur_state->dolqstart = NULL;
+						BEGIN(INITIAL);
+					}
+					else
+					{
+						/*
+						 * When we fail to match $...$ to dolqstart, transfer
+						 * the $... part to the output, but put back the final
+						 * $ for rescanning.  Consider $delim$...$junk$delim$
+						 */
+						yyless(yyleng - 1);
+					}
+					/* ignore */
+				}
+<xdolq>{dolqinside} {
+					/* ignore */
+				}
+<xdolq>{dolqfailed} {
+					/* ignore */
+				}
+<xdolq>.		{
+					/* This is only needed for $ inside the quoted text */
+					/* ignore */
+				}
+
+{xdstart}		{
+					BEGIN(xd);
+					/* ignore */
+				}
+{xuistart}		{
+					BEGIN(xui);
+					/* ignore */
+				}
+<xd>{xdstop}	{
+					BEGIN(INITIAL);
+					/* ignore */
+				}
+<xui>{dquote}	{
+					BEGIN(INITIAL);
+					/* ignore */
+				}
+<xd,xui>{xddouble}	{
+					/* ignore */
+				}
+<xd,xui>{xdinside}	{
+					/* ignore */
+				}
+
+{xufailed}	{
+					/* throw back all but the initial u/U */
+					yyless(1);
+					/* ignore */
+				}
+
+{typecast}		{
+					/* ignore */
+				}
+
+{dot_dot}		{
+					/* ignore */
+				}
+
+{colon_equals}	{
+					/* ignore */
+				}
+
+{equals_greater} {
+					/* ignore */
+				}
+
+{less_equals}	{
+					/* ignore */
+				}
+
+{greater_equals} {
+					/* ignore */
+				}
+
+{less_greater}	{
+					/* ignore */
+				}
+
+{not_equals}	{
+					/* ignore */
+				}
+
+{self}			{
+					/* ignore */
+				}
+
+{operator}		{
+					/*
+					 * Check for embedded slash-star or dash-dash; those
+					 * are comment starts, so operator must stop there.
+					 * Note that slash-star or dash-dash at the first
+					 * character will match a prior rule, not this one.
+					 */
+					int			nchars = yyleng;
+					char	   *slashstar = strstr(yytext, "/*");
+					char	   *dashdash = strstr(yytext, "--");
+
+					if (slashstar && dashdash)
+					{
+						/* if both appear, take the first one */
+						if (slashstar > dashdash)
+							slashstar = dashdash;
+					}
+					else if (!slashstar)
+						slashstar = dashdash;
+					if (slashstar)
+						nchars = slashstar - yytext;
+
+					/*
+					 * For SQL compatibility, '+' and '-' cannot be the
+					 * last char of a multi-char operator unless the operator
+					 * contains chars that are not in SQL operators.
+					 * The idea is to lex '=-' as two operators, but not
+					 * to forbid operator names like '?-' that could not be
+					 * sequences of SQL operators.
+					 */
+					if (nchars > 1 &&
+						(yytext[nchars - 1] == '+' ||
+						 yytext[nchars - 1] == '-'))
+					{
+						int			ic;
+
+						for (ic = nchars - 2; ic >= 0; ic--)
+						{
+							char c = yytext[ic];
+							if (c == '~' || c == '!' || c == '@' ||
+								c == '#' || c == '^' || c == '&' ||
+								c == '|' || c == '`' || c == '?' ||
+								c == '%')
+								break;
+						}
+						if (ic < 0)
+						{
+							/*
+							 * didn't find a qualifying character, so remove
+							 * all trailing [+-]
+							 */
+							do {
+								nchars--;
+							} while (nchars > 1 &&
+								 (yytext[nchars - 1] == '+' ||
+								  yytext[nchars - 1] == '-'));
+						}
+					}
+
+					if (nchars < yyleng)
+					{
+						/* Strip the unwanted chars from the token */
+						yyless(nchars);
+					}
+					/* ignore */
+				}
+
+{param}			{
+					/* ignore */
+				}
+{param_junk}	{
+					/* ignore */
+				}
+
+{decinteger}	{
+					/* ignore */
+				}
+{hexinteger}	{
+					/* ignore */
+				}
+{octinteger}	{
+					/* ignore */
+				}
+{bininteger}	{
+					/* ignore */
+				}
+{hexfail}		{
+					/* ignore */
+				}
+{octfail}		{
+					/* ignore */
+				}
+{binfail}		{
+					/* ignore */
+				}
+{numeric}		{
+					/* ignore */
+				}
+{numericfail}	{
+					/* throw back the .., and treat as integer */
+					yyless(yyleng - 2);
+					/* ignore */
+				}
+{real}			{
+					/* ignore */
+				}
+{realfail}		{
+					/* ignore */
+				}
+{decinteger_junk}	{
+					/* ignore */
+				}
+{hexinteger_junk}	{
+					/* ignore */
+				}
+{octinteger_junk}	{
+					/* ignore */
+				}
+{bininteger_junk}	{
+					/* ignore */
+				}
+{numeric_junk}	{
+					/* ignore */
+				}
+{real_junk}		{
+					/* ignore */
+				}
+
+
+{identifier}	{
+					/*
+					 * We need to track if we are inside a BEGIN .. END block
+					 * in a function definition, so that semicolons contained
+					 * therein don't terminate the whole statement.  Short of
+					 * writing a full parser here, the following heuristic
+					 * should work.  First, we track whether the beginning of
+					 * the statement matches CREATE [OR REPLACE]
+					 * {FUNCTION|PROCEDURE}
+					 */
+
+					if (cur_state->identifier_count == 0)
+						memset(cur_state->identifiers, 0, sizeof(cur_state->identifiers));
+
+					if (pg_strcasecmp(yytext, "create") == 0 ||
+						pg_strcasecmp(yytext, "function") == 0 ||
+						pg_strcasecmp(yytext, "procedure") == 0 ||
+						pg_strcasecmp(yytext, "or") == 0 ||
+						pg_strcasecmp(yytext, "replace") == 0)
+					{
+						if (cur_state->identifier_count < sizeof(cur_state->identifiers))
+							cur_state->identifiers[cur_state->identifier_count] = pg_tolower((unsigned char) yytext[0]);
+					}
+
+					cur_state->identifier_count++;
+
+					if (cur_state->identifiers[0] == 'c' &&
+						(cur_state->identifiers[1] == 'f' || cur_state->identifiers[1] == 'p' ||
+						 (cur_state->identifiers[1] == 'o' && cur_state->identifiers[2] == 'r' &&
+						  (cur_state->identifiers[3] == 'f' || cur_state->identifiers[3] == 'p'))) &&
+						cur_state->paren_depth == 0)
+					{
+						if (pg_strcasecmp(yytext, "begin") == 0)
+							cur_state->begin_depth++;
+						else if (pg_strcasecmp(yytext, "case") == 0)
+						{
+							/*
+							 * CASE also ends with END.  We only need to track
+							 * this if we are already inside a BEGIN.
+							 */
+							if (cur_state->begin_depth >= 1)
+								cur_state->begin_depth++;
+						}
+						else if (pg_strcasecmp(yytext, "end") == 0)
+						{
+							if (cur_state->begin_depth > 0)
+								cur_state->begin_depth--;
+						}
+					}
+
+					/* ignore */
+				}
+
+{other}			{
+					/* ignore */
+				}
+
+<<EOF>>			{
+					cur_state->start_state = YY_START;
+					return LEXRES_EOL;	/* end of input reached */
+				}
+
+%%
+
+/* LCOV_EXCL_STOP */
+
+/*
+ * Create a lexer working state struct.
+ */
+QueryScanState
+query_scan_create(void)
+{
+	QueryScanState state;
+
+	state = (QueryScanStateData *) palloc0(sizeof(QueryScanStateData));
+	yylex_init(&state->scanner);
+
+	yyset_extra(state, state->scanner);
+
+	/* Set up various fields */
+	state->start_state = INITIAL;
+	state->elevel = INFO;
+	state->paren_depth = 0;
+	state->xcdepth = 0;			/* not really necessary */
+	state->xhintnum = 0;
+	if (state->dolqstart)
+		pfree(state->dolqstart);
+	state->dolqstart = NULL;
+	state->identifier_count = 0;
+	state->begin_depth = 0;
+
+	return state;
+}
+
+
+/*
+ * Set up to perform lexing of the given input line.
+ *
+ * The text at *line, extending for line_len bytes, will be scanned by
+ * subsequent calls to the query_scan routines.  query_scan_finish should
+ * be called when scanning is complete.  Note that the lexer retains
+ * a pointer to the storage at *line --- this string must not be altered
+ * or freed until after query_scan_finish is called.
+ *
+ * encoding is the libpq identifier for the character encoding in use,
+ * and std_strings says whether standard_conforming_strings is on.
+ */
+void
+query_scan_setup(QueryScanState state,
+				const char *line, int line_len,
+				int encoding, bool std_strings, int elevel)
+{
+	/* Mustn't be scanning already */
+	Assert(state->scanbufhandle == NULL);
+
+	/* elevel for reports */
+	state->elevel = elevel;
+
+	/* Do we need to hack the character set encoding? */
+	state->encoding = encoding;
+	state->safe_encoding = pg_valid_server_encoding_id(encoding);
+
+	/* Save standard-strings flag as well */
+	state->std_strings = std_strings;
+
+	/* Set up flex input buffer with appropriate translation and padding */
+	state->scanbufhandle = query_scan_prepare_buffer(state, line, line_len,
+												   &state->scanbuf);
+	state->scanline = line;
+
+	/* Set lookaside data in case we have to map unsafe encoding */
+	state->curline = state->scanbuf;
+	state->refline = state->scanline;
+}
+
+/*
+ * Do lexical analysis of SQL command text.
+ *
+ * The text previously passed to query_scan_setup is scanned, and appended
+ * (possibly with transformation) to query_buf.
+ *
+ * The return value indicates the condition that stopped scanning:
+ *
+ * QUERY_SCAN_INCOMPLETE: the end of the line was reached, but we have an
+ * incomplete SQL command.
+ *
+ * QUERY_SCAN_EOL: the end of the line was reached, and there is no lexical
+ * reason to consider the command incomplete.  The caller may or may not
+ * choose to send it.
+ *
+ * In the QUERY_SCAN_INCOMPLETE and QUERY_SCAN_EOL cases, query_scan_finish()
+ * should be called next, then the cycle may be repeated with a fresh input
+ * line.
+ */
+QueryScanResult
+query_scan(QueryScanState state,
+		  StringInfo query_buf)
+{
+	QueryScanResult result;
+	int			lexresult;
+
+	/* Must be scanning already */
+	Assert(state->scanbufhandle != NULL);
+
+	/* Set current output target */
+	state->output_buf = query_buf;
+
+	yy_switch_to_buffer(state->scanbufhandle, state->scanner);
+
+	/* And lex. */
+	lexresult = yylex(NULL, state->scanner);
+
+	/*
+	 * Check termination state and return appropriate result info.
+	 */
+	switch (lexresult)
+	{
+		case LEXRES_EOL:		/* end of input */
+			switch (state->start_state)
+			{
+				case INITIAL:
+				case xqs:		/* we treat this like INITIAL */
+					if (state->paren_depth > 0)
+					{
+						result = QUERY_SCAN_INCOMPLETE;
+					}
+					else if (state->begin_depth > 0)
+					{
+						result = QUERY_SCAN_INCOMPLETE;
+					}
+					else
+					{
+						/* the resulting query may be empty if there are no hints */
+						result = QUERY_SCAN_EOL;
+					}
+					break;
+				case xb:
+				case xc:
+				case xd:
+				case xh:
+				case xhint:
+				case xe:
+				case xq:
+				case xdolq:
+				case xui:
+				case xus:
+					result = QUERY_SCAN_INCOMPLETE;
+					break;
+				default:
+					/* can't get here */
+					elog(ERROR, "invalid YY_START");
+			}
+			break;
+		default:
+			/* can't get here */
+			elog(ERROR, "invalid yylex result\n");
+	}
+
+	return result;
+}
+
+/*
+ * Clean up after scanning a string.  This flushes any unread input and
+ * releases resources (but not the QueryScanState itself).  Note however
+ * that this does not reset the lexer scan state.
+ *
+ * It is legal to call this when not scanning anything (makes it easier
+ * to deal with error recovery).
+ */
+void
+query_scan_finish(QueryScanState state)
+{
+	/* Done with the outer scan buffer, too */
+	if (state->scanbufhandle)
+		yy_delete_buffer(state->scanbufhandle, state->scanner);
+	state->scanbufhandle = NULL;
+	if (state->scanbuf)
+		pfree(state->scanbuf);
+	state->scanbuf = NULL;
+
+	yylex_destroy(state->scanner);
+	pfree(state);
+}
+
+
+/*
+ * Set up a flex input buffer to scan the given data.  We always make a
+ * copy of the data.  If working in an unsafe encoding, the copy has
+ * multibyte sequences replaced by FFs to avoid fooling the lexer rules.
+ *
+ * NOTE SIDE EFFECT: the new buffer is made the active flex input buffer.
+ */
+YY_BUFFER_STATE
+query_scan_prepare_buffer(QueryScanState state, const char *txt, int len,
+						char **txtcopy)
+{
+	char	   *newtxt;
+
+	/* Flex wants two \0 characters after the actual data */
+	newtxt = palloc(len + 2);
+	*txtcopy = newtxt;
+	newtxt[len] = newtxt[len + 1] = YY_END_OF_BUFFER_CHAR;
+
+	if (state->safe_encoding)
+		memcpy(newtxt, txt, len);
+	else
+	{
+		/* Gotta do it the hard way */
+		int			i = 0;
+
+		while (i < len)
+		{
+			int			thislen = pg_encoding_mblen(state->encoding,
+									    txt + i);
+
+			/* first byte should always be okay... */
+			newtxt[i] = txt[i];
+			i++;
+			while (--thislen > 0 && i < len)
+				newtxt[i++] = (char) 0xFF;
+		}
+	}
+
+	return yy_scan_buffer(newtxt, len + 2, state->scanner);
+}
+
+void
+query_yyerror(int elevel, const char *txt, const char *message)
+{
+	ereport(elevel,
+		errmsg("pg_hint_plan: hint syntax error at or near \"%s\"", txt),
+		errdetail("%s", message));
+}
+
+/*
+ * query_scan_emit() --- body for ECHO macro
+ *
+ * NB: this must be used for ALL and ONLY the text copied from the flex
+ * input data.  If you pass it something that is not part of the yytext
+ * string, you are making a mistake.  Internally generated text can be
+ * appended directly to state->output_buf.
+ */
+void
+query_scan_emit(QueryScanState state, const char *txt, int len)
+{
+	StringInfo output_buf = state->output_buf;
+
+	if (state->safe_encoding)
+		appendBinaryStringInfo(output_buf, txt, len);
+	else
+	{
+		/* Gotta do it the hard way */
+		const char *reference = state->refline;
+		int			i;
+
+		reference += (txt - state->curline);
+
+		for (i = 0; i < len; i++)
+		{
+			char		ch = txt[i];
+
+			if (ch == (char) 0xFF)
+				ch = reference[i];
+			appendStringInfoChar(output_buf, ch);
+		}
+	}
+}

--- a/query_scan_int.h
+++ b/query_scan_int.h
@@ -1,0 +1,120 @@
+/*-------------------------------------------------------------------------
+ *
+ * query_scan_int.h
+ *	  lexical scanner internal declarations
+ *
+ * This file declares the QueryScanStateData structure used by query_scan.l.
+ *
+ * One difficult aspect of this code is that we need to work in multibyte
+ * encodings that are not ASCII-safe.  A "safe" encoding is one in which each
+ * byte of a multibyte character has the high bit set (it's >= 0x80).  Since
+ * all our lexing rules treat all high-bit-set characters alike, we don't
+ * really need to care whether such a byte is part of a sequence or not.
+ * In an "unsafe" encoding, we still expect the first byte of a multibyte
+ * sequence to be >= 0x80, but later bytes might not be.  If we scan such
+ * a sequence as-is, the lexing rules could easily be fooled into matching
+ * such bytes to ordinary ASCII characters.  Our solution for this is to
+ * substitute 0xFF for each non-first byte within the data presented to flex.
+ * The flex rules will then pass the FF's through unmolested.  The
+ * query_scan_emit() subroutine is responsible for looking back to the
+ * original string and replacing FF's with the corresponding original bytes.
+ *
+ * Another interesting thing we do here is scan different parts of the same
+ * input with physically separate flex lexers (ie, lexers written in separate
+ * .l files).  We can get away with this because the only part of the
+ * persistent state of a flex lexer that depends on its parsing rule tables
+ * is the start state number, which is easy enough to manage --- usually,
+ * in fact, we just need to set it to INITIAL when changing lexers.  But to
+ * make that work at all, we must use re-entrant lexers, so that all the
+ * relevant state is in the yyscan_t attached to the QueryScanState;
+ * if we were using lexers with separate static state we would soon end up
+ * with dangling buffer pointers in one or the other.  Also note that this
+ * is unlikely to work very nicely if the lexers aren't all built with the
+ * same flex version, or if they don't use the same flex options.
+ *
+ *
+ * Portions Copyright (c) 1996-2023, PostgreSQL Global Development Group
+ * Portions Copyright (c) 1994, Regents of the University of California
+ *
+ * query_scan_int.h
+ *
+ *-------------------------------------------------------------------------
+ */
+#ifndef QUERY_SCAN_INT_H
+#define QUERY_SCAN_INT_H
+
+#include "query_scan.h"
+
+/*
+ * These are just to allow this file to be compilable standalone for header
+ * validity checking; in actual use, this file should always be included
+ * from the body of a flex file, where these symbols are already defined.
+ */
+#ifndef YY_TYPEDEF_YY_BUFFER_STATE
+#define YY_TYPEDEF_YY_BUFFER_STATE
+typedef struct yy_buffer_state *YY_BUFFER_STATE;
+#endif
+#ifndef YY_TYPEDEF_YY_SCANNER_T
+#define YY_TYPEDEF_YY_SCANNER_T
+typedef void *yyscan_t;
+#endif
+
+/*
+ * All working state of the lexer must be stored in QueryScanStateData
+ * between calls.  This allows us to have multiple open lexer operations,
+ * which is needed for nested include files.  The lexer itself is not
+ * recursive, but it must be re-entrant.
+ */
+typedef struct QueryScanStateData
+{
+	yyscan_t	scanner;		/* Flex's state for this QueryScanState */
+
+	StringInfo	output_buf;		/* current output buffer */
+
+	int			elevel;			/* level of reports generated at parsing */
+
+	/*
+	 * These variables always refer to the outer buffer, never to any stacked
+	 * variable-expansion buffer.
+	 */
+	YY_BUFFER_STATE scanbufhandle;
+	char	   *scanbuf;		/* start of outer-level input buffer */
+	const char *scanline;		/* current input line at outer level */
+
+	/* safe_encoding, curline, refline are used by emit() to replace FFs */
+	int			encoding;		/* encoding being used now */
+	bool		safe_encoding;	/* is current encoding "safe"? */
+	bool		std_strings;	/* are string literals standard? */
+	const char *curline;		/* actual flex input string for cur buf */
+	const char *refline;		/* original data for cur buffer */
+
+	/*
+	 * All this state lives across successive input lines.  start_state is
+	 * adopted by yylex() on entry, and updated with its finishing state on
+	 * exit.
+	 */
+	int			start_state;	/* yylex's starting/finishing state */
+	int			state_before_str_stop;	/* start cond. before end quote */
+	int			paren_depth;	/* depth of nesting in parentheses */
+	int			xcdepth;		/* depth of nesting in slash-star comments */
+	char	   *dolqstart;		/* current $foo$ quote start string */
+	int			xhintnum;		/* number of query hints found */
+
+	/*
+	 * State to track boundaries of BEGIN ... END blocks in function
+	 * definitions, so that semicolons do not send query too early.
+	 */
+	int			identifier_count;	/* identifiers since start of statement */
+	char		identifiers[4]; /* records the first few identifiers */
+	int			begin_depth;	/* depth of begin/end pairs */
+} QueryScanStateData;
+
+
+extern YY_BUFFER_STATE query_scan_prepare_buffer(QueryScanState state,
+											   const char *txt, int len,
+											   char **txtcopy);
+extern void query_yyerror(int elevel, const char *txt, const char *message);
+
+extern void query_scan_emit(QueryScanState state, const char *txt, int len);
+
+#endif							/* QUERY_SCAN_INT_H */


### PR DESCRIPTION
This commit adds a lexer to pg_hint_plan to properly parse the hints from query strings.  This implementation is based on PostgreSQL's psqlscan.l, which is largely simplified and made pluggable for the sake of this module as it mostly cares about detecting comments and hints in queries.

This has the advantage of removing all the custom code that pg_hint_plan has invented to parse the query strings, cleaning up some confusing historical behaviors in the module:
- A qual value could be considered as a valid hint, like: SELECT * FROM tab WHERE col = '/* IndexScan (tab) */'; This is now parsed as a value, as it should.
- The parsing of the comments was sometimes incorrect, failing to ignore comments that would make hints invalid.  For example: SELECT /* IndexScan (tab /* internal_comment */ ) */ FROM tab; Any comments internal to the hints are now automatically discarded.

Attempting to use nested comments generates INFO messages each time something fishy is found.  Like before this commit, the hints behave the same way.

Note that this makes the GUC pg_hint_plan.hints_anywhere not needed anymore.  This will be removed in a follow-up commit.