### PR TITLE
Fix handling of mix cased alias names

### DIFF
--- a/expected/pg_hint_plan.out
+++ b/expected/pg_hint_plan.out
@@ -9106,6 +9106,26 @@ error hint:
          Sort Key: t3.id
          ->  Seq Scan on t3  (cost=xxx..xxx rows=100 width=xxx)
 
+-- case insensitve alias
+\o results/pg_hint_plan.tmpout
+/*+ Rows(aliast1 aliasT2 #42) */
+EXPLAIN SELECT * FROM t1 AS aliasT1 JOIN t2 AS aliasT2 ON (aliasT1.id = aliasT2.id);
+LOG:  pg_hint_plan:
+used hint:
+Rows(aliast1 aliasT2 #42)
+not used hint:
+duplication hint:
+error hint:
+
+\o
+\! sql/maskout.sh results/pg_hint_plan.tmpout
+  QUERY PLAN
+----------------
+ Merge Join  (cost=xxx..xxx rows=42 width=xxx)
+   Merge Cond: (aliast1.id = aliast2.id)
+   ->  Index Scan using t1_pkey on t1 aliast1  (cost=xxx..xxx rows=10000 width=xxx)
+   ->  Index Scan using t2_pkey on t2 aliast2  (cost=xxx..xxx rows=1000 width=xxx)
+
 \o results/pg_hint_plan.tmpout
 /*+ Rows(t1 t3 *10) */
 EXPLAIN SELECT * FROM t1 JOIN t2 ON (t1.id = t2.id) JOIN t3 ON (t3.id = t2.id);

--- a/pg_hint_plan.c
+++ b/pg_hint_plan.c
@@ -1454,7 +1454,7 @@ RelnameCmp(const void *a, const void *b)
 	const char *relnamea = *((const char **) a);
 	const char *relnameb = *((const char **) b);
 
-	return strcmp(relnamea, relnameb);
+	return pg_strcasecmp(relnamea, relnameb);
 }
 
 static int

--- a/sql/pg_hint_plan.sql
+++ b/sql/pg_hint_plan.sql
@@ -1152,6 +1152,13 @@ EXPLAIN SELECT * FROM t1 JOIN t2 ON (t1.id = t2.id) JOIN t3 ON (t3.id = t2.id);
 \o
 \! sql/maskout.sh results/pg_hint_plan.tmpout
 
+-- case insensitve alias
+\o results/pg_hint_plan.tmpout
+/*+ Rows(aliast1 aliasT2 #42) */
+EXPLAIN SELECT * FROM t1 AS aliasT1 JOIN t2 AS aliasT2 ON (aliasT1.id = aliasT2.id);
+\o
+\! sql/maskout.sh results/pg_hint_plan.tmpout
+
 \o results/pg_hint_plan.tmpout
 /*+ Rows(t1 t3 *10) */
 EXPLAIN SELECT * FROM t1 JOIN t2 ON (t1.id = t2.id) JOIN t3 ON (t3.id = t2.id);


### PR DESCRIPTION
It seems to me that hints should probably be case insensitive to alias names.
Before this patch, hints that included uppercase alias names could be ignored. 

Example:
```sql
CREATE TABLE t1(a1 int, b1 int);
CREATE TABLE t2(a2 int, b2 int);
```

Before:

```sql
/*+
    Rows(aliasT1 t2 #42)
 */
EXPLAIN SELECT * FROM t1 AS aliasT1 join t2 on aliasT1.a1=a2;
                           QUERY PLAN                           
----------------------------------------------------------------
 Nested Loop  (cost=0.00..0.01 rows=1 width=16)
   ...
```

After:
```sql
/*+                 
    Rows(aliasT1 t2 #42)
 */
EXPLAIN SELECT * FROM t1 AS aliasT1 join t2 on aliasT1.a1=a2;
                             QUERY PLAN                             
----------------------------------------------------------------
 Nested Loop  (cost=0.00..0.01 rows=42 width=16)
   ...
```