### PR TITLE
add META.json for PGXN distribution

### DIFF
--- a/META.json
+++ b/META.json
@@ -1,0 +1,45 @@
+{
+    "name": "pg_hint_plan16",
+    "abstract": "pg_hint_plan makes it possible to tweak PostgreSQL execution plans using so-called 'hints' in SQL comments, like /*+ SeqScan(a) */.",
+    "description": "PostgreSQL uses a cost-based optimizer, which utilizes data statistics, not static rules. The planner (optimizer) esitimates costs of each possible execution plans for a SQL statement then the execution plan with the lowest cost finally be executed. The planner does its best to select the best best execution plan, but is not always perfect, since it doesn't count some properties of the data, for example, correlation between columns. For more details, please see the various documentations available in the docs/ directory.",
+    "version": "1.6.0",
+    "maintainer": [
+        "Github Issues <no-reply@fake.local>"
+    ],
+    "license": "bsd",
+    "prereqs": {
+        "runtime": {
+            "requires": {
+                "PostgreSQL": ">= 16.0.0, < 17.0.0"
+            }
+        }
+    },
+    "provides": {
+       "pg_hint_plan": {
+            "abstract": "pg_hint_plan makes it possible to tweak PostgreSQL execution plans using so-called 'hints' in SQL comments, like /*+ SeqScan(a) */.",
+            "file": "pg_hint_plan--1.3.0.sql",
+            "docfile": "README.md",
+            "version": "1.6.0"
+       }
+    },
+    "resources": {
+        "bugtracker": {
+            "web": "https://github.com/ossc-db/pg_hint_plan/issues"
+        },
+        "repository": {
+            "url":  "https://github.com/ossc-db/pg_hint_plan.git",
+            "web":  "https://github.com/ossc-db/pg_hint_plan/",
+            "type": "git"
+        }
+    },
+    "meta-spec": {
+        "version": "1.0.0",
+        "url": "https://pgxn.org/meta/spec.txt"
+    },
+    "tags": [
+        "sql",
+        "plan",
+        "performance",
+        "hint"
+    ]
+ }


### PR DESCRIPTION
It would be great to distribute pg_hint_plan on PGXN.  In order to do that, we'll need a `META.json` file with the metadata needed by PGXN to catalog and manage the extension.  This PR has a proposal.

few notes about this draft (open to discussion):
* intend not to commit any META.json to master branch but only to PG version branches from 11 to 16.  Planning to use `"requires": { "PostgreSQL": ">= 16.0.0, < 17.0.0" }` for each one, and name the overall PGXN distro with the major version like “pg_hint_plan16".  this matches the releases currently being done on github which are also titled like "pg_hint_plan16".
* this proposal puts the same pg_hint_plan version in both the PGXN distro and the PGXN package; we’d update both when we advance the pg_hint_plan version
* i think i did the right thing with the PGXN “file” tag, since ISTM that pg_hint_plan always runs through all the update to install the latest version
* PGXN requires a 'maintainer' name and email address in its metadata. AFAICT pg_hint_plan doesn't publicly list names of any individual maintainers at this time, and from what I can see the official way to contact maintainers is through GitHub issues. I used a dummy email that indicates this in the proposal here. however, if possible, it might be nice to list a few names in the META.json, if everyone agrees to have their name listed with an appropriate email address that can be used here.

once things are agreed on, I can create PRs for branches from v11 to v15.  (or if github supports multiple branches in a single PR then i can do that, i just haven't tried this yet to see if it works.)