### PR TITLE
Fix Read the Docs build errors

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,20 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
+  jobs:
+    pre_install:
+      # The following code is necessary to avoid PyYAML installation errors.
+      # See https://github.com/yaml/pyyaml/issues/724#issuecomment-1638636728
+      - python -m pip install --upgrade --no-cache-dir --no-build-isolation pyyaml==6.0
+
+sphinx:
+  configuration: docs/conf.py
+
+formats: all
+
+python:
+  install:
+    - requirements: docs/requirements.txt


### PR DESCRIPTION
I have just noticed that Read the Docs has been failing to build for about a year.
The following are the areas that need to be changed.
- .readthedocs.yaml needs to exist in the repository root (https://blog.readthedocs.com/migrate-configuration-v2/)
- PyYAML installation errors need to be addressed (https://github.com/yaml/pyyaml/issues/724#issuecomment-1638636728)