### PR TITLE
Enable all join operators for all joins for n rels if there is no join hint for n rels

### DIFF
--- a/expected/pg_hint_plan.out
+++ b/expected/pg_hint_plan.out
@@ -852,17 +852,17 @@ error hint:
                     QUERY PLAN                    
 --------------------------------------------------
  Nested Loop
-   ->  Nested Loop
+   ->  Merge Join
+         Merge Cond: (t3.id = t1.id)
          ->  Merge Join
                Merge Cond: (t3.id = t4.id)
                ->  Index Scan using t3_pkey on t3
                ->  Sort
                      Sort Key: t4.id
                      ->  Seq Scan on t4
-         ->  Index Scan using t2_pkey on t2
-               Index Cond: (id = t3.id)
-   ->  Index Scan using t1_pkey on t1
-         Index Cond: (id = t2.id)
+         ->  Index Scan using t1_pkey on t1
+   ->  Index Scan using t2_pkey on t2
+         Index Cond: (id = t1.id)
 (12 rows)
 
 /*+Leading(t3 t4 t1)*/
@@ -5680,18 +5680,19 @@ not used hint:
 duplication hint:
 error hint:
 
-                 QUERY PLAN                 
---------------------------------------------
- Nested Loop
-   Join Filter: (t2.val = t3.val)
-   ->  Hash Join
-         Hash Cond: (t1.id = t2.id)
-         ->  Index Scan using t1_pkey on t1
-               Index Cond: (id < 10)
-         ->  Hash
-               ->  Seq Scan on t2
+                    QUERY PLAN                    
+--------------------------------------------------
+ Hash Join
+   Hash Cond: (t3.val = t2.val)
    ->  Seq Scan on t3
-(9 rows)
+   ->  Hash
+         ->  Hash Join
+               Hash Cond: (t1.id = t2.id)
+               ->  Index Scan using t1_pkey on t1
+                     Index Cond: (id < 10)
+               ->  Hash
+                     ->  Seq Scan on t2
+(10 rows)
 
 /*+Leading((t1 t2 t3))*/
 EXPLAIN (COSTS false) SELECT * FROM t1, t2, t3 WHERE t1.id = t2.id AND t2.val = t3.val AND t1.id < 10;
@@ -6183,7 +6184,6 @@ error hint:
                     QUERY PLAN                    
 --------------------------------------------------
  Nested Loop
-   Join Filter: (t3.id = t4.id)
    ->  Nested Loop
          Join Filter: (t1.val = t3.val)
          ->  Hash Join
@@ -6193,7 +6193,8 @@ error hint:
                ->  Hash
                      ->  Seq Scan on t2
          ->  Seq Scan on t3
-   ->  Seq Scan on t4
+   ->  Index Scan using t4_pkey on t4
+         Index Cond: (id = t3.id)
 (12 rows)
 
 /*+Leading(((t1 t2) t3)) MergeJoin(t1 t2 t3 t4)*/
@@ -9226,7 +9227,8 @@ error hint:
 
                    QUERY PLAN                    
 -------------------------------------------------
- Nested Loop
+ Merge Join
+   Merge Cond: (t1.id = t3.id)
    ->  Merge Join
          Merge Cond: (t2.id = t1.id)
          ->  Index Scan using t2_pkey on t2
@@ -9235,7 +9237,8 @@ error hint:
                ->  Gather
                      Workers Planned: 8
                      ->  Parallel Seq Scan on t1
-   ->  Index Scan using t3_pkey on t3
-         Index Cond: (id = t1.id)
-(11 rows)
+   ->  Sort
+         Sort Key: t3.id
+         ->  Seq Scan on t3
+(13 rows)
 

--- a/expected/ut-L.out
+++ b/expected/ut-L.out
@@ -4278,18 +4278,19 @@ error hint:
                    QUERY PLAN                   
 ------------------------------------------------
  Nested Loop
-   Join Filter: (t1.c1 = t4.c1)
-   ->  Nested Loop
-         Join Filter: (t1.c1 = t2.c1)
-         ->  Nested Loop
-               ->  Index Scan using t2_i1 on t2
-               ->  Index Scan using t3_i1 on t3
-                     Index Cond: (c1 = t2.c1)
+   ->  Merge Join
+         Merge Cond: (t1.c1 = t2.c1)
          ->  Index Scan using t1_i1 on t1
-               Index Cond: (c1 = t3.c1)
+         ->  Sort
+               Sort Key: t2.c1
+               ->  Hash Join
+                     Hash Cond: (t2.c1 = t3.c1)
+                     ->  Seq Scan on t2
+                     ->  Hash
+                           ->  Seq Scan on t3
    ->  Index Scan using t4_i1 on t4
-         Index Cond: (c1 = t3.c1)
-(12 rows)
+         Index Cond: (c1 = t1.c1)
+(13 rows)
 
 -- No. L-3-6-3
 /*+Leading((t2 t3 t4))*/

--- a/expected/ut-R.out
+++ b/expected/ut-R.out
@@ -2582,8 +2582,8 @@ error hint:
 \! sql/maskout.sh results/ut-R.tmpout
   QUERY PLAN
 ----------------
- Nested Loop  (cost=xxx..xxx rows=10 width=xxx)
-   Join Filter: (bmt1.c1 = bmt2.c1)
+ Merge Join  (cost=xxx..xxx rows=10 width=xxx)
+   Merge Cond: (bmt1.c1 = bmt2.c1)
    InitPlan 1 (returns $0)
      ->  Merge Join  (cost=xxx..xxx rows=100 width=xxx)
            Merge Cond: (b2t1.c1 = b2t2.c1)
@@ -2598,7 +2598,7 @@ error hint:
            ->  Sort  (cost=xxx..xxx rows=100 width=xxx)
                  Sort Key: b3t2.c1
                  ->  Seq Scan on t2 b3t2  (cost=xxx..xxx rows=100 width=xxx)
-   ->  Nested Loop  (cost={inf}..{inf} rows=100 width=xxx)
+   ->  Nested Loop  (cost=xxx..xxx rows=100 width=xxx)
          ->  Merge Join  (cost=xxx..xxx rows=100 width=xxx)
                Merge Cond: (b1t1.c1 = b1t2.c1)
                ->  Index Only Scan using t1_i1 on t1 b1t1  (cost=xxx..xxx rows=1000 width=xxx)
@@ -2608,8 +2608,9 @@ error hint:
          ->  Index Only Scan using t1_i1 on t1 bmt1  (cost=xxx..xxx rows=1 width=xxx)
                Index Cond: (c1 = b1t1.c1)
                Filter: (c1 <> $1)
-   ->  Index Only Scan using t2_i1 on t2 bmt2  (cost=xxx..xxx rows=1 width=xxx)
-         Index Cond: (c1 = b1t1.c1)
+   ->  Sort  (cost=xxx..xxx rows=100 width=xxx)
+         Sort Key: bmt2.c1
+         ->  Seq Scan on t2 bmt2  (cost=xxx..xxx rows=100 width=xxx)
 
 \o results/ut-R.tmpout
 /*+
@@ -2665,8 +2666,8 @@ error hint:
 \! sql/maskout.sh results/ut-R.tmpout
   QUERY PLAN
 ----------------
- Nested Loop  (cost=xxx..xxx rows=10 width=xxx)
-   Join Filter: (bmt1.c1 = bmt2.c1)
+ Merge Join  (cost=xxx..xxx rows=10 width=xxx)
+   Merge Cond: (bmt1.c1 = bmt2.c1)
    InitPlan 1 (returns $0)
      ->  Merge Join  (cost=xxx..xxx rows=1 width=xxx)
            Merge Cond: (b2t1.c1 = b2t2.c1)
@@ -2681,7 +2682,7 @@ error hint:
            ->  Sort  (cost=xxx..xxx rows=100 width=xxx)
                  Sort Key: b3t2.c1
                  ->  Seq Scan on t2 b3t2  (cost=xxx..xxx rows=100 width=xxx)
-   ->  Nested Loop  (cost={inf}..{inf} rows=100 width=xxx)
+   ->  Nested Loop  (cost=xxx..xxx rows=100 width=xxx)
          ->  Merge Join  (cost=xxx..xxx rows=1 width=xxx)
                Merge Cond: (b1t1.c1 = b1t2.c1)
                ->  Index Only Scan using t1_i1 on t1 b1t1  (cost=xxx..xxx rows=1000 width=xxx)
@@ -2691,8 +2692,9 @@ error hint:
          ->  Index Only Scan using t1_i1 on t1 bmt1  (cost=xxx..xxx rows=1 width=xxx)
                Index Cond: (c1 = b1t1.c1)
                Filter: (c1 <> $1)
-   ->  Index Only Scan using t2_i1 on t2 bmt2  (cost=xxx..xxx rows=1 width=xxx)
-         Index Cond: (c1 = b1t1.c1)
+   ->  Sort  (cost=xxx..xxx rows=100 width=xxx)
+         Sort Key: bmt2.c1
+         ->  Seq Scan on t2 bmt2  (cost=xxx..xxx rows=100 width=xxx)
 
 -- No. R-2-2-3
 \o results/ut-R.tmpout
@@ -2753,8 +2755,8 @@ error hint:
 \! sql/maskout.sh results/ut-R.tmpout
   QUERY PLAN
 ----------------
- Nested Loop  (cost=xxx..xxx rows=10 width=xxx)
-   Join Filter: (bmt1.c1 = bmt4.c1)
+ Merge Join  (cost=xxx..xxx rows=10 width=xxx)
+   Merge Cond: (bmt1.c1 = bmt2.c1)
    InitPlan 1 (returns $1)
      ->  Merge Join  (cost=xxx..xxx rows=100 width=xxx)
            Merge Cond: (b2t1.c1 = b2t2.c1)
@@ -2783,12 +2785,9 @@ error hint:
                                    ->  Seq Scan on t4 b3t4  (cost=xxx..xxx rows=1130 width=xxx)
                        ->  Index Only Scan using t2_i1 on t2 b3t2  (cost=xxx..xxx rows=1 width=xxx)
                              Index Cond: (c1 = b3t3.c1)
-   ->  Nested Loop  (cost=xxx..xxx rows=10 width=xxx)
-         Join Filter: (bmt1.c1 = bmt3.c1)
-         ->  Nested Loop  (cost=xxx..xxx rows=10 width=xxx)
-               Join Filter: (bmt1.c1 = bmt2.c1)
-               ->  Nested Loop  (cost={inf}..{inf} rows=100 width=xxx)
-                     Join Filter: (bmt1.c1 = b1t1.c1)
+   ->  Nested Loop  (cost=xxx..xxx rows=100 width=xxx)
+         ->  Nested Loop  (cost=xxx..xxx rows=88 width=xxx)
+               ->  Nested Loop  (cost=xxx..xxx rows=88 width=xxx)
                      ->  Merge Join  (cost=xxx..xxx rows=100 width=xxx)
                            Merge Cond: (b1t1.c1 = b1t2.c1)
                            ->  Index Only Scan using t1_i1 on t1 b1t1  (cost=xxx..xxx rows=1000 width=xxx)
@@ -2802,15 +2801,16 @@ error hint:
                                                    ->  Seq Scan on t4 b1t4  (cost=xxx..xxx rows=1130 width=xxx)
                                        ->  Index Only Scan using t2_i1 on t2 b1t2  (cost=xxx..xxx rows=1 width=xxx)
                                              Index Cond: (c1 = b1t3.c1)
-                     ->  Index Only Scan using t1_i1 on t1 bmt1  (cost=xxx..xxx rows=1 width=xxx)
-                           Index Cond: (c1 = b1t3.c1)
-                           Filter: (c1 <> $3)
-               ->  Index Only Scan using t2_i1 on t2 bmt2  (cost=xxx..xxx rows=1 width=xxx)
-                     Index Cond: (c1 = b1t3.c1)
-         ->  Index Only Scan using t3_i1 on t3 bmt3  (cost=xxx..xxx rows=1 width=xxx)
-               Index Cond: (c1 = b1t3.c1)
-   ->  Index Only Scan using t4_i1 on t4 bmt4  (cost=xxx..xxx rows=1 width=xxx)
-         Index Cond: (c1 = bmt3.c1)
+                     ->  Index Only Scan using t3_i1 on t3 bmt3  (cost=xxx..xxx rows=1 width=xxx)
+                           Index Cond: (c1 = b1t1.c1)
+               ->  Index Only Scan using t4_i1 on t4 bmt4  (cost=xxx..xxx rows=1 width=xxx)
+                     Index Cond: (c1 = bmt3.c1)
+         ->  Index Only Scan using t1_i1 on t1 bmt1  (cost=xxx..xxx rows=1 width=xxx)
+               Index Cond: (c1 = bmt3.c1)
+               Filter: (c1 <> $3)
+   ->  Sort  (cost=xxx..xxx rows=100 width=xxx)
+         Sort Key: bmt2.c1
+         ->  Seq Scan on t2 bmt2  (cost=xxx..xxx rows=100 width=xxx)
 
 \o results/ut-R.tmpout
 /*+
@@ -2897,7 +2897,6 @@ error hint:
   QUERY PLAN
 ----------------
  Nested Loop  (cost=xxx..xxx rows=10 width=xxx)
-   Join Filter: (bmt1.c1 = bmt4.c1)
    InitPlan 1 (returns $1)
      ->  Merge Join  (cost=xxx..xxx rows=1 width=xxx)
            Merge Cond: (b2t1.c1 = b2t2.c1)
@@ -2927,11 +2926,9 @@ error hint:
                        ->  Index Only Scan using t2_i1 on t2 b3t2  (cost=xxx..xxx rows=1 width=xxx)
                              Index Cond: (c1 = b3t3.c1)
    ->  Nested Loop  (cost=xxx..xxx rows=10 width=xxx)
-         Join Filter: (bmt1.c1 = bmt3.c1)
-         ->  Nested Loop  (cost=xxx..xxx rows=10 width=xxx)
-               Join Filter: (bmt1.c1 = bmt2.c1)
-               ->  Nested Loop  (cost={inf}..{inf} rows=100 width=xxx)
-                     Join Filter: (bmt1.c1 = b1t1.c1)
+         ->  Merge Join  (cost=xxx..xxx rows=10 width=xxx)
+               Merge Cond: (bmt1.c1 = bmt2.c1)
+               ->  Nested Loop  (cost=xxx..xxx rows=100 width=xxx)
                      ->  Merge Join  (cost=xxx..xxx rows=1 width=xxx)
                            Merge Cond: (b1t1.c1 = b1t2.c1)
                            ->  Index Only Scan using t1_i1 on t1 b1t1  (cost=xxx..xxx rows=1000 width=xxx)
@@ -2946,14 +2943,15 @@ error hint:
                                        ->  Index Only Scan using t2_i1 on t2 b1t2  (cost=xxx..xxx rows=1 width=xxx)
                                              Index Cond: (c1 = b1t3.c1)
                      ->  Index Only Scan using t1_i1 on t1 bmt1  (cost=xxx..xxx rows=1 width=xxx)
-                           Index Cond: (c1 = b1t3.c1)
+                           Index Cond: (c1 = b1t1.c1)
                            Filter: (c1 <> $3)
-               ->  Index Only Scan using t2_i1 on t2 bmt2  (cost=xxx..xxx rows=1 width=xxx)
-                     Index Cond: (c1 = b1t3.c1)
+               ->  Sort  (cost=xxx..xxx rows=100 width=xxx)
+                     Sort Key: bmt2.c1
+                     ->  Seq Scan on t2 bmt2  (cost=xxx..xxx rows=100 width=xxx)
          ->  Index Only Scan using t3_i1 on t3 bmt3  (cost=xxx..xxx rows=1 width=xxx)
-               Index Cond: (c1 = b1t3.c1)
+               Index Cond: (c1 = bmt1.c1)
    ->  Index Only Scan using t4_i1 on t4 bmt4  (cost=xxx..xxx rows=1 width=xxx)
-         Index Cond: (c1 = bmt3.c1)
+         Index Cond: (c1 = bmt1.c1)
 
 -- No. R-2-2-4
 \o results/ut-R.tmpout
@@ -2999,22 +2997,20 @@ error hint:
   QUERY PLAN
 ----------------
  Nested Loop  (cost=xxx..xxx rows=10 width=xxx)
-   Join Filter: (bmt1.c1 = bmt4.c1)
    InitPlan 1 (returns $0)
      ->  Index Only Scan using t1_i1 on t1 b2t1  (cost=xxx..xxx rows=1 width=xxx)
            Index Cond: (c1 = 1)
    InitPlan 2 (returns $1)
      ->  Seq Scan on t1 b3t1  (cost=xxx..xxx rows=1000 width=xxx)
    ->  Nested Loop  (cost=xxx..xxx rows=10 width=xxx)
-         Join Filter: (bmt1.c1 = bmt3.c1)
-         ->  Nested Loop  (cost=xxx..xxx rows=10 width=xxx)
-               Join Filter: (bmt1.c1 = bmt2.c1)
-               ->  Nested Loop  (cost={inf}..{inf} rows=100 width=xxx)
-                     Join Filter: (bmt2.c1 = b1t1.c1)
-                     ->  Index Only Scan using t2_i1 on t2 bmt2  (cost=xxx..xxx rows=100 width=xxx)
-                     ->  Materialize  (cost=xxx..xxx rows=100 width=xxx)
-                           ->  Nested Loop  (cost=xxx..xxx rows=100 width=xxx)
-                                 Join Filter: (b1t1.c1 = b1t2.c1)
+         ->  Merge Join  (cost=xxx..xxx rows=10 width=xxx)
+               Merge Cond: (bmt2.c1 = bmt1.c1)
+               ->  Merge Join  (cost=xxx..xxx rows=100 width=xxx)
+                     Merge Cond: (b1t1.c1 = bmt2.c1)
+                     ->  Nested Loop  (cost=xxx..xxx rows=100 width=xxx)
+                           Join Filter: (b1t1.c1 = b1t2.c1)
+                           ->  Index Only Scan using t1_i1 on t1 b1t1  (cost=xxx..xxx rows=1000 width=xxx)
+                           ->  Materialize  (cost=xxx..xxx rows=100 width=xxx)
                                  ->  Hash Join  (cost=xxx..xxx rows=100 width=xxx)
                                        Hash Cond: (b1t3.c1 = b1t2.c1)
                                        ->  Merge Join  (cost=xxx..xxx rows=1130 width=xxx)
@@ -3023,15 +3019,15 @@ error hint:
                                              ->  Index Only Scan using t4_i1 on t4 b1t4  (cost=xxx..xxx rows=1130 width=xxx)
                                        ->  Hash  (cost=xxx..xxx rows=100 width=xxx)
                                              ->  Seq Scan on t2 b1t2  (cost=xxx..xxx rows=100 width=xxx)
-                                 ->  Index Only Scan using t1_i1 on t1 b1t1  (cost=xxx..xxx rows=1 width=xxx)
-                                       Index Cond: (c1 = b1t3.c1)
-               ->  Index Only Scan using t1_i1 on t1 bmt1  (cost=xxx..xxx rows=1 width=xxx)
-                     Index Cond: (c1 = b1t3.c1)
+                     ->  Sort  (cost=xxx..xxx rows=100 width=xxx)
+                           Sort Key: bmt2.c1
+                           ->  Seq Scan on t2 bmt2  (cost=xxx..xxx rows=100 width=xxx)
+               ->  Index Only Scan using t1_i1 on t1 bmt1  (cost=xxx..xxx rows=999 width=xxx)
                      Filter: (c1 <> $1)
          ->  Index Only Scan using t3_i1 on t3 bmt3  (cost=xxx..xxx rows=1 width=xxx)
-               Index Cond: (c1 = b1t3.c1)
+               Index Cond: (c1 = bmt1.c1)
    ->  Index Only Scan using t4_i1 on t4 bmt4  (cost=xxx..xxx rows=1 width=xxx)
-         Index Cond: (c1 = bmt3.c1)
+         Index Cond: (c1 = bmt1.c1)
 
 \o results/ut-R.tmpout
 /*+
@@ -3090,39 +3086,36 @@ error hint:
   QUERY PLAN
 ----------------
  Nested Loop  (cost=xxx..xxx rows=10 width=xxx)
-   Join Filter: (bmt1.c1 = bmt4.c1)
    InitPlan 1 (returns $0)
      ->  Index Only Scan using t1_i1 on t1 b2t1  (cost=xxx..xxx rows=1 width=xxx)
            Index Cond: (c1 = 1)
    InitPlan 2 (returns $1)
      ->  Seq Scan on t1 b3t1  (cost=xxx..xxx rows=1000 width=xxx)
    ->  Nested Loop  (cost=xxx..xxx rows=10 width=xxx)
-         Join Filter: (bmt1.c1 = bmt3.c1)
-         ->  Nested Loop  (cost=xxx..xxx rows=10 width=xxx)
-               Join Filter: (bmt1.c1 = bmt2.c1)
-               ->  Nested Loop  (cost={inf}..{inf} rows=100 width=xxx)
-                     Join Filter: (bmt2.c1 = b1t1.c1)
-                     ->  Index Only Scan using t2_i1 on t2 bmt2  (cost=xxx..xxx rows=100 width=xxx)
-                     ->  Materialize  (cost=xxx..xxx rows=1 width=xxx)
-                           ->  Nested Loop  (cost=xxx..xxx rows=1 width=xxx)
-                                 Join Filter: (b1t1.c1 = b1t2.c1)
-                                 ->  Hash Join  (cost=xxx..xxx rows=1 width=xxx)
-                                       Hash Cond: (b1t3.c1 = b1t2.c1)
-                                       ->  Merge Join  (cost=xxx..xxx rows=1 width=xxx)
-                                             Merge Cond: (b1t3.c1 = b1t4.c1)
-                                             ->  Index Only Scan using t3_i1 on t3 b1t3  (cost=xxx..xxx rows=1130 width=xxx)
-                                             ->  Index Only Scan using t4_i1 on t4 b1t4  (cost=xxx..xxx rows=1130 width=xxx)
-                                       ->  Hash  (cost=xxx..xxx rows=100 width=xxx)
-                                             ->  Seq Scan on t2 b1t2  (cost=xxx..xxx rows=100 width=xxx)
-                                 ->  Index Only Scan using t1_i1 on t1 b1t1  (cost=xxx..xxx rows=1 width=xxx)
-                                       Index Cond: (c1 = b1t3.c1)
-               ->  Index Only Scan using t1_i1 on t1 bmt1  (cost=xxx..xxx rows=1 width=xxx)
-                     Index Cond: (c1 = b1t3.c1)
-                     Filter: (c1 <> $1)
+         ->  Hash Join  (cost=xxx..xxx rows=10 width=xxx)
+               Hash Cond: (bmt1.c1 = bmt2.c1)
+               ->  Nested Loop  (cost=xxx..xxx rows=100 width=xxx)
+                     ->  Nested Loop  (cost=xxx..xxx rows=1 width=xxx)
+                           Join Filter: (b1t1.c1 = b1t2.c1)
+                           ->  Hash Join  (cost=xxx..xxx rows=1 width=xxx)
+                                 Hash Cond: (b1t3.c1 = b1t2.c1)
+                                 ->  Merge Join  (cost=xxx..xxx rows=1 width=xxx)
+                                       Merge Cond: (b1t3.c1 = b1t4.c1)
+                                       ->  Index Only Scan using t3_i1 on t3 b1t3  (cost=xxx..xxx rows=1130 width=xxx)
+                                       ->  Index Only Scan using t4_i1 on t4 b1t4  (cost=xxx..xxx rows=1130 width=xxx)
+                                 ->  Hash  (cost=xxx..xxx rows=100 width=xxx)
+                                       ->  Seq Scan on t2 b1t2  (cost=xxx..xxx rows=100 width=xxx)
+                           ->  Index Only Scan using t1_i1 on t1 b1t1  (cost=xxx..xxx rows=1 width=xxx)
+                                 Index Cond: (c1 = b1t3.c1)
+                     ->  Index Only Scan using t1_i1 on t1 bmt1  (cost=xxx..xxx rows=1 width=xxx)
+                           Index Cond: (c1 = b1t1.c1)
+                           Filter: (c1 <> $1)
+               ->  Hash  (cost=xxx..xxx rows=100 width=xxx)
+                     ->  Seq Scan on t2 bmt2  (cost=xxx..xxx rows=100 width=xxx)
          ->  Index Only Scan using t3_i1 on t3 bmt3  (cost=xxx..xxx rows=1 width=xxx)
-               Index Cond: (c1 = b1t3.c1)
+               Index Cond: (c1 = bmt1.c1)
    ->  Index Only Scan using t4_i1 on t4 bmt4  (cost=xxx..xxx rows=1 width=xxx)
-         Index Cond: (c1 = bmt3.c1)
+         Index Cond: (c1 = bmt1.c1)
 
 ----
 ---- No. R-2-3 RULE or VIEW

--- a/pg_hint_plan.c
+++ b/pg_hint_plan.c
@@ -4612,6 +4612,12 @@ add_paths_to_joinrel_wrapper(PlannerInfo *root,
 
 	join_hint = find_join_hint(joinrelids);
 	memoize_hint = find_memoize_hint(joinrelids);
+
+	/* enable all join operators if there is no join hint for n rels */
+	if(current_hint_state->join_hint_level[bms_num_members(joinrelids)]==0)
+		set_join_config_options(ENABLE_ALL_JOIN, false,
+								current_hint_state->context);
+
 	bms_free(joinrelids);
 
 	/* reject the found hints if they don't match this join */


### PR DESCRIPTION
Hi, I created this pull request to solve problems introduced in #207 which I will introduce later. But this pull request is independent of #207 and it only modifies several lines of code.

For a query (from a test file) with hints like
```
/*+Leading( t3 t4 ) */ 
explain SELECT * FROM t1, t2, t3, t4 WHERE t1.id = t2.id AND t1.id = t3.id AND t1.id = t4.id;
```

The hint only includes the join hints for join (t3 t4) and the generated plan is
```
                                      QUERY PLAN                                       
---------------------------------------------------------------------------------------
 Nested Loop  (cost=20000000001.97..20000000010.32 rows=1 width=32)
   ->  Nested Loop  (cost=10000000001.68..10000000009.72 rows=1 width=24)
         ->  Merge Join  (cost=1.41..2.80 rows=10 width=16)
               Merge Cond: (t3.id = t4.id)
               ->  Index Scan using t3_pkey on t3  (cost=0.14..13.64 rows=100 width=8)
               ->  Sort  (cost=1.27..1.29 rows=10 width=8)
                     Sort Key: t4.id
                     ->  Seq Scan on t4  (cost=0.00..1.10 rows=10 width=8)
         ->  Index Scan using t2_pkey on t2  (cost=0.28..0.69 rows=1 width=8)
               Index Cond: (id = t3.id)
   ->  Index Scan using t1_pkey on t1  (cost=0.29..0.60 rows=1 width=8)
         Index Cond: (id = t2.id)
(12 rows)
```

In this plan, a ``disable_cost`` (1e10) has been added to the cost of nestloop(t2 t3 t4) and two have been added to nestloop(t1 t2 t3 t4). This is because pg_hint adds a ``disable_cost`` to the cost of all joins without a join hint, even if there is no join hint for all joins with the same number of relations. In this example, a ``disable_cost`` will be added to all joins with 3 relations and two will be added to all joins with 4 relations. 

It may be more reasonable to omit to add a ``disable_cost`` to all joins involving n relations if no join hint is provided for such joins. What's more, we want to enlarge the ``disable_cost`` to 1e20 in #207. Such a large disable_cost will lead to the wrong comparison of the costs of two disabled paths. For example, if the actual cost of the disabled path A is 12.3 and the actual cost of the disabled path B is 20, with a disable_cost (1e20), they will have the same cost because float only has approximately 15-17 decimal digits of precision. Thus, a worse path will be selected in some cases. Therefore, we should omit to add a ``disable_cost`` to all joins involving n relations if no join hint is provided for such joins.

After applying this modification, I ran the test and found some queries generated different plans with the expected. The following is one example from test ``pg_hint_plan.sql``.
```
Query
------
/*+Leading( t3 t4 )*/
EXPLAIN (COSTS false) SELECT * FROM t1, t2, t3, t4 WHERE t1.id = t2.id AND t1.id = t3.id AND t1.id = t4.id;
```
```
Actual Plan
-----------
                                      QUERY PLAN                                       
---------------------------------------------------------------------------------------
 Nested Loop  (cost=1.97..6.93 rows=1 width=32)
   ->  Merge Join  (cost=1.69..6.64 rows=1 width=24)
         Merge Cond: (t3.id = t1.id)
         ->  Merge Join  (cost=1.41..2.80 rows=10 width=16)
               Merge Cond: (t3.id = t4.id)
               ->  Index Scan using t3_pkey on t3  (cost=0.14..13.64 rows=100 width=8)
               ->  Sort  (cost=1.27..1.29 rows=10 width=8)
                     Sort Key: t4.id
                     ->  Seq Scan on t4  (cost=0.00..1.10 rows=10 width=8)
         ->  Index Scan using t1_pkey on t1  (cost=0.29..318.29 rows=10000 width=8)
   ->  Index Scan using t2_pkey on t2  (cost=0.28..0.30 rows=1 width=8)
         Index Cond: (id = t1.id)
(12 rows)
```
```
Expected Plan (generated with additional hints)
-----------------------------------------------
                                      QUERY PLAN                                       
---------------------------------------------------------------------------------------
 Nested Loop  (cost=1.97..10.32 rows=1 width=32)
   ->  Nested Loop  (cost=1.68..9.72 rows=1 width=24)
         ->  Merge Join  (cost=1.41..2.80 rows=10 width=16)
               Merge Cond: (t3.id = t4.id)
               ->  Index Scan using t3_pkey on t3  (cost=0.14..13.64 rows=100 width=8)
               ->  Sort  (cost=1.27..1.29 rows=10 width=8)
                     Sort Key: t4.id
                     ->  Seq Scan on t4  (cost=0.00..1.10 rows=10 width=8)
         ->  Index Scan using t2_pkey on t2  (cost=0.28..0.69 rows=1 width=8)
               Index Cond: (id = t3.id)
   ->  Index Scan using t1_pkey on t1  (cost=0.29..0.60 rows=1 width=8)
         Index Cond: (id = t2.id)
(12 rows)
```
We could see that the expected plan in the test file has a larger cost than the actual generated plan. I checked all differences and found all actual plans have less costs.So if we apply this modification, we need to update the expected plans for test sqls. I hope you apply this modification and check if you will generate different plans with the expected plans.

In summary, I want to demonstrate two things in this pull request:
- It may be more reasonable to omit to add a ``disable_cost`` to all joins involving n relations if no join hint is provided for such joins.
- With the above modifications, the expected results of test sqls may need to be updated.

Hope your reply!