### PR TITLE
docs: clarify that multiple hint comments cause errors

### DIFF
--- a/docs/hint_details.md
+++ b/docs/hint_details.md
@@ -2,11 +2,12 @@
 
 ## Syntax and placement
 
-`pg_hint_plan` reads hints from only the first block comment and stops parsing
-from any characters except alphabetical characters, digits, spaces,
-underscores, commas and parentheses.  In the following example,
-`HashJoin(a b)` and `SeqScan(a)` are parsed as hints, but `IndexScan(a)` and
-`MergeJoin(a b)` are not:
+`pg_hint_plan` reads hints from only the first block comment and any additional
+hint comments cause an error.  Hint parsing also stops from any characters
+except alphabetical characters, digits, spaces, underscores, commas and
+parentheses.  In the following example, `HashJoin(a b)` and `SeqScan(a)` are
+parsed as hints, but `IndexScan(a)` and `MergeJoin(a b)` cause errors because
+they are in separate hint comments:
 
 ```sql
 =# /*+
@@ -127,7 +128,8 @@ children have no effect.
 ## Hints in multistatements
 
 One multistatement can have exactly one hint comment and the hint affects all
-of the individual statements in the multistatement.
+of the individual statements in the multistatement.  Multiple hint comments
+in a multistatement cause an error.
 
 ## VALUES expressions
 


### PR DESCRIPTION
## Summary

- Since [`bfb4544`](https://github.com/ossc-db/pg_hint_plan/commit/bfb45447c9d4181790519c8ef4041c6b9e98fbff) (PostgreSQL 17+), the query lexer raises an `ERROR` when a query contains more than one hint comment (`/*+ ... */`). The previous documentation implied these were silently ignored.
- Updated "Syntax and placement" and "Hints in multistatements" sections to reflect the actual behavior.

## Discussion

It may be worth considering whether additional hint comments should produce a `WARNING` (or be ignored at a configurable `message_level`) rather than a hard `ERROR`. The current behavior is a breaking change for queries that previously worked with PostgreSQL 16 — e.g. subqueries that repeat the same hint, or ORMs/query builders that naively attach hints at multiple levels. A warning-based approach would preserve the "use only the first hint" semantics while still informing users.