### PR TITLE
Use PG_MODULE_MAGIC_EXT in PostgreSQL 18 and later

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,8 @@ DATA = \
 
 EXTRA_CLEAN = RPMS
 
+PG_CFLAGS += -DHINTPLANVER=\"$(HINTPLANVER)\"
+
 # Switch environment between standalone make and make check with
 # EXTRA_INSTALL from PostgreSQL tree
 # run the following command in the PG tree to run a regression test

--- a/pg_hint_plan.c
+++ b/pg_hint_plan.c
@@ -61,7 +61,9 @@
 /* PostgreSQL */
 #include "access/htup_details.h"
 
-#ifdef PG_MODULE_MAGIC
+#if defined(PG_MODULE_MAGIC_EXT)
+PG_MODULE_MAGIC_EXT(.name = "pg_hint_plan", .version = HINTPLANVER);
+#elif defined(PG_MODULE_MAGIC)
 PG_MODULE_MAGIC;
 #endif
 


### PR DESCRIPTION
The `PG_MODULE_MAGIC_EXT` macro was added in PostgreSQL 18 and makes it possible to see which version of the library is actually loaded using `pg_get_loaded_modules()`.