### PR TITLE
Handle NULL index name values

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ OBJS = \
 HINTPLANVER = 1.7.2
 
 REGRESS = init base_plan pg_hint_plan ut-init ut-A ut-S ut-J ut-L ut-G ut-R \
-	ut-fdw ut-W ut-T ut-fini plpgsql hint_table query_parser \
+	ut-fdw ut-W ut-T ut-fini plpgsql hint_table hypopg query_parser \
 	oldextversions
 REGRESS_OPTS = --encoding=UTF8
 

--- a/expected/hypopg.out
+++ b/expected/hypopg.out
@@ -1,0 +1,54 @@
+-- Test hypothetical indexes with hypopg
+-- Skip test if hypopg is not installed.
+SELECT count(*) = 0 AS hypopg_missing FROM pg_available_extensions
+  WHERE name = 'hypopg' \gset
+\if :hypopg_missing
+\quit
+\endif
+LOAD 'pg_hint_plan';
+CREATE EXTENSION hypopg;
+CREATE TABLE hypopg_t1(a int, b int, c int);
+CREATE INDEX hypopg_t1_a_idx ON hypopg_t1 (a);
+SELECT hypopg_create_index('CREATE INDEX hypopg_t1_b_idx ON hypopg_t1 (b)');
+       hypopg_create_index        
+----------------------------------
+ (13630,<13630>btree_hypopg_t1_b)
+(1 row)
+
+EXPLAIN (COSTS OFF) SELECT /*+ IndexScan(hypopg_t1 hypopg_t1_a_idx) */
+  FROM hypopg_t1 WHERE a = 3 AND b = 4;
+                  QUERY PLAN                   
+-----------------------------------------------
+ Index Scan using hypopg_t1_a_idx on hypopg_t1
+   Index Cond: (a = 3)
+   Filter: (b = 4)
+(3 rows)
+
+EXPLAIN (COSTS OFF) SELECT /*+ IndexScan(hypopg_t1 hypopg_t1_b_idx) */
+  FROM hypopg_t1 WHERE a = 3 AND b = 4;
+                         QUERY PLAN                          
+-------------------------------------------------------------
+ Bitmap Heap Scan on hypopg_t1
+   Recheck Cond: ((b = 4) AND (a = 3))
+   ->  BitmapAnd
+         ->  Bitmap Index Scan on "<13630>btree_hypopg_t1_b"
+               Index Cond: (b = 4)
+         ->  Bitmap Index Scan on hypopg_t1_a_idx
+               Index Cond: (a = 3)
+(7 rows)
+
+EXPLAIN (COSTS OFF) SELECT /*+ IndexScan(hypopg_t1 btree_hypopg_t1_b) */
+  FROM hypopg_t1 WHERE a = 3 AND b = 4;
+                         QUERY PLAN                          
+-------------------------------------------------------------
+ Bitmap Heap Scan on hypopg_t1
+   Recheck Cond: ((b = 4) AND (a = 3))
+   ->  BitmapAnd
+         ->  Bitmap Index Scan on "<13630>btree_hypopg_t1_b"
+               Index Cond: (b = 4)
+         ->  Bitmap Index Scan on hypopg_t1_a_idx
+               Index Cond: (a = 3)
+(7 rows)
+
+DROP TABLE hypopg_t1;
+DROP EXTENSION hypopg;

--- a/expected/hypopg_1.out
+++ b/expected/hypopg_1.out
@@ -1,0 +1,6 @@
+-- Test hypothetical indexes with hypopg
+-- Skip test if hypopg is not installed.
+SELECT count(*) = 0 AS hypopg_missing FROM pg_available_extensions
+  WHERE name = 'hypopg' \gset
+\if :hypopg_missing
+\quit

--- a/pg_hint_plan.c
+++ b/pg_hint_plan.c
@@ -3437,6 +3437,12 @@ restrict_indexes(PlannerInfo *root, ScanMethodHint *hint, RelOptInfo *rel,
 		ListCell	   *l;
 		bool			use_index = false;
 
+		if (indexname == NULL)
+		{
+			unused_indexes = lappend_oid(unused_indexes, info->indexoid);
+			continue;
+		}
+
 		foreach(l, hint->indexnames)
 		{
 			char   *hintname = (char *) lfirst(l);

--- a/sql/hypopg.sql
+++ b/sql/hypopg.sql
@@ -1,0 +1,25 @@
+-- Test hypothetical indexes with hypopg
+
+-- Skip test if hypopg is not installed.
+SELECT count(*) = 0 AS hypopg_missing FROM pg_available_extensions
+  WHERE name = 'hypopg' \gset
+\if :hypopg_missing
+\quit
+\endif
+
+LOAD 'pg_hint_plan';
+
+CREATE EXTENSION hypopg;
+CREATE TABLE hypopg_t1(a int, b int, c int);
+CREATE INDEX hypopg_t1_a_idx ON hypopg_t1 (a);
+SELECT hypopg_create_index('CREATE INDEX hypopg_t1_b_idx ON hypopg_t1 (b)');
+
+EXPLAIN (COSTS OFF) SELECT /*+ IndexScan(hypopg_t1 hypopg_t1_a_idx) */
+  FROM hypopg_t1 WHERE a = 3 AND b = 4;
+EXPLAIN (COSTS OFF) SELECT /*+ IndexScan(hypopg_t1 hypopg_t1_b_idx) */
+  FROM hypopg_t1 WHERE a = 3 AND b = 4;
+EXPLAIN (COSTS OFF) SELECT /*+ IndexScan(hypopg_t1 btree_hypopg_t1_b) */
+  FROM hypopg_t1 WHERE a = 3 AND b = 4;
+
+DROP TABLE hypopg_t1;
+DROP EXTENSION hypopg;


### PR DESCRIPTION
`get_rel_name` returns a `*char` value, which can be NULL. Failure to handle this causes a segmentation fault, which causes the database to crash. Without an index name we can't determine whether or not to apply a hint.
This is an alternative to the fix proposed in https://github.com/michaelpq/pg_hint_plan/tree/hypothetical_index_17, rather than explicitly handling hypothetical indexes (which is a bit of an edge case and requires maintaining compatibility with the hypopg plugin), we just skip any index that returns NULL from `get_rel_name`

Fixes #205 